### PR TITLE
Modified Vim Editing Layout

### DIFF
--- a/DotFiles/.gvimrc
+++ b/DotFiles/.gvimrc
@@ -111,6 +111,7 @@ unlet s:cpo_save
 
 " macVim Custom Editor Settings
 
-" set guifont=Menlo:h14
+" Set Default font
+" set guifont=Menlo:h14 - Original Default
 set guifont=-monospace-:h14
 

--- a/DotFiles/.vimrc
+++ b/DotFiles/.vimrc
@@ -43,5 +43,9 @@ endif
 
 " Vim and macVim Custom Editor Settings
 
+" Map L1 to open Lexplore mode - Non-Recursive Mapping
+nnoremap L1 :Lexplore<CR>:vertical resize 30<CR>
+" Display line numbers in files
 set number
+" Set default colorscheme
 colorscheme mustang_vim_colorscheme_by_hcalves_d1mxd78


### PR DESCRIPTION
Added new "L1" mapping to Lexplore to provide for diaplaying File listing on left of Vim editor and contents on right.