### PR TITLE
Update .gvimrc

### DIFF
--- a/DotFiles/.gvimrc
+++ b/DotFiles/.gvimrc
@@ -114,5 +114,6 @@ unlet s:cpo_save
 " Set Default font
 " set guifont=Menlo:h14 - Original Default
 " set guifont=-monospace-:h14 - System Default
-set guifont=Jetbrains\ Mono:h14
+" set guifont=Jetbrains\ Mono:h14
+set guifont=MesloLGS\ NF:h14
 


### PR DESCRIPTION
Changed MacVim default font to MesloLGS NF in order to support Powerlevel10k Vim Theme.