### PR TITLE
Update otp_generator.py

### DIFF
--- a/PythonCode/otp_generator.py
+++ b/PythonCode/otp_generator.py
@@ -107,10 +107,32 @@ class OTPManager:
     def list_names(self):
         """List all saved OTP names"""
         return list(self.secrets.keys())
+    
+    def get_raw_secrets(self):
+        """Get the raw secrets JSON for display"""
+        return json.dumps(self.secrets, indent=2)
 
 def clear_screen():
     """Clear the terminal screen"""
     os.system('cls' if os.name == 'nt' else 'clear')
+
+def dump_option(manager):
+    """
+    Display the contents of the encrypted keys file and wait for user input.
+    
+    Args:
+        manager (OTPManager): The OTP manager instance
+    """
+    clear_screen()
+    print("\033[1;34mDisplaying contents of encrypted keys file:\033[0m")
+    print("\n")
+    
+    # Display the raw secrets data
+    raw_secrets = manager.get_raw_secrets()
+    print(raw_secrets)
+    
+    print("\n")
+    input("Press Enter to continue...")
 
 def main():
     # Configuration for keychain access
@@ -159,6 +181,7 @@ def main():
         print("a - Add new OTP secret")
         print("r - Remove OTP secret")
         print("f - Refresh codes")
+        print("d - Dump raw keys file contents")  # Added new option
         print("q - Quit")
         
         choice = input("\nEnter option: ").lower()
@@ -183,6 +206,9 @@ def main():
         elif choice == 'f':
             # Refresh is just continuing the loop, which redraws the screen
             continue
+        
+        elif choice == 'd':  # Added new case for dump option
+            dump_option(manager)
             
         elif choice == 'q':
             break


### PR DESCRIPTION
Added new displaying of encrypted keys file.
This pull request introduces a new feature to the `PythonCode/otp_generator.py` script, allowing users to dump and display the raw contents of the encrypted keys file. The most important changes include the addition of a method to retrieve raw secrets, a new function to handle the dump option, and updates to the main menu to incorporate this new feature.

New feature implementation:

* [`PythonCode/otp_generator.py`](diffhunk://#diff-d7e7b360c09ed29e74c5fae106523446185c693395207460f08142844e397d46R111-R136): Added the `get_raw_secrets` method to the `OTPManager` class to retrieve the raw secrets in JSON format.
* [`PythonCode/otp_generator.py`](diffhunk://#diff-d7e7b360c09ed29e74c5fae106523446185c693395207460f08142844e397d46R111-R136): Introduced the `dump_option` function to display the contents of the encrypted keys file and wait for user input.
* [`PythonCode/otp_generator.py`](diffhunk://#diff-d7e7b360c09ed29e74c5fae106523446185c693395207460f08142844e397d46R184): Updated the `main` function to include a new menu option 'd' for dumping raw keys file contents and handle the corresponding case. [[1]](diffhunk://#diff-d7e7b360c09ed29e74c5fae106523446185c693395207460f08142844e397d46R184) [[2]](diffhunk://#diff-d7e7b360c09ed29e74c5fae106523446185c693395207460f08142844e397d46R210-R212)