### PR TITLE
Added New Zsh OTP Manager

### DIFF
--- a/ShellScripts/Crypm.sh
+++ b/ShellScripts/Crypm.sh
@@ -36,6 +36,10 @@ function otpzsh {
 	ZshOtpGenerator.sh
 }
 
+function otpzshmgr {
+	ZshOtpManager.sh
+}
+
 function menu {
 	clear
 	echo
@@ -44,9 +48,10 @@ function menu {
 	echo -e "\t2. SSL Cryptxt"
 	echo -e "\t3. SSL Crypvault"
 	echo -e "\t4. Gauth Authenticator"
-	echo -e "\t5. Gauth Manager"
-	echo -e "\t6. OTP Python Manager"
+	echo -e "\t5. Gauth OTP Manager"
+	echo -e "\t6. Python Authenticator / OTP Manager"
 	echo -e "\t7. Zsh Authenticator"
+	echo -e "\t8. Zsh OTP Manager"
 	echo -e "\t0. Exit Menu\n\n"
 	echo -en "\t\tEnter an Option: "
         # Read entire input instead of just one character
@@ -83,6 +88,9 @@ while true; do
 		;;
 	    7)
 	        otpzsh
+		;;
+	    8)
+	        otpzshmgr
 		;;
             *)
                 clear

--- a/ShellScripts/ZshOtpGenerator.sh
+++ b/ShellScripts/ZshOtpGenerator.sh
@@ -304,6 +304,7 @@ enable_non_blocking
 trap "cleanup_and_exit" SIGINT
 
 # Print startup message
+clear
 echo "Starting TOTP viewer..."
 echo "Press 'q' to quit anytime"
 sleep 1

--- a/ShellScripts/ZshOtpManager.sh
+++ b/ShellScripts/ZshOtpManager.sh
@@ -1,0 +1,136 @@
+#!/bin/zsh
+# Set secure file locations
+ENCRYPTED_FILE="$HOME/.otp_secrets_zsh.enc"
+DECRYPTED_FILE="$(mktemp)"
+# Terminal colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+# Trap for ensuring cleanup on exit
+trap cleanup_and_exit INT TERM EXIT
+# Function to print error messages
+error_print() {
+    local message="$1"
+    local exit_after="${2:-false}"
+    
+    printf "${RED}%s${NC}\n" "$message" >&2
+    
+    if [[ "$exit_after" == "true" ]]; then
+        cleanup_and_exit
+    fi
+}
+# Function to retrieve password from keychain
+get_password() {
+    # Load Hash_CFG
+    local secret_type="OTPGenerator"
+    local account="MasterPassword"
+    
+    # Lookup Secret in Keychain
+    local secret
+    if ! secret=$(security find-generic-password -w -s "$secret_type" -a "$account" 2>/dev/null); then
+        error_print "Secret Not Found, error $?" true
+        return 1
+    fi
+    
+    # Set File Hash and Temporary Environment variable
+    GAUTH_PASSWORD=$(printf "%s" "$secret" | base64 --decode)
+    
+    if [[ -z "$GAUTH_PASSWORD" ]]; then
+        error_print "Failed to decode password" true
+        return 1
+    fi
+    return 0
+}
+# Function for decryption of otp secrets file
+decrypt_file() {
+    if [[ ! -f "$ENCRYPTED_FILE" ]]; then
+        error_print "Error: Encrypted file doesn't exist at $ENCRYPTED_FILE" true
+        return 1
+    fi
+    
+    if ! openssl enc -d -aes-256-cbc -salt -pass pass:"$GAUTH_PASSWORD" -pbkdf2 -iter 1000000 -in "$ENCRYPTED_FILE" -out "$DECRYPTED_FILE" 2>/dev/null; then
+        error_print "Error: Decryption failed." true
+        return 1
+    fi
+    
+    return 0
+}
+# Function for encryption of otp secrets file
+encrypt_file() {
+    if ! openssl enc -aes-256-cbc -salt -pass pass:"$GAUTH_PASSWORD" -pbkdf2 -iter 1000000 -in "$DECRYPTED_FILE" -out "$ENCRYPTED_FILE" 2>/dev/null; then
+        error_print "Error: Re-encryption failed!" true
+        return 1
+    fi
+    
+    printf "${GREEN}File successfully re-encrypted.${NC}\n"
+    return 0
+}
+# Function to cleanup and exit
+cleanup_and_exit() {
+    # Securely remove the decrypted file
+    if [[ -f "$DECRYPTED_FILE" ]]; then
+        rm -P "$DECRYPTED_FILE" 2>/dev/null || rm "$DECRYPTED_FILE"
+    fi
+    
+    # Unset the password variable
+    unset GAUTH_PASSWORD
+    
+    # Only print goodbye message if not already exiting due to error
+    if [[ $? -eq 0 ]]; then
+        printf "\n${BLUE}Exiting Zsh OTP Manager. Goodbye!${NC}\n"
+    fi
+    
+    # Remove the trap before exiting to prevent recursive calls
+    trap - INT TERM EXIT
+    exit $?
+}
+# Main execution
+# Clear the terminal
+clear
+# Check if MacVim is installed
+if ! command -v mvim >/dev/null 2>&1; then
+    error_print "Error: MacVim is not installed or not in PATH." true
+fi
+# Retrieve password from keychain
+if ! get_password; then
+    error_print "Error: Failed to retrieve password from keychain." true
+fi
+# Decrypt the file
+if ! decrypt_file; then
+    error_print "Error: Failed to decrypt file." true
+fi
+# Open the decrypted file in MacVim
+printf "${CYAN}Opening secret file in MacVim...${NC}\n"
+open -a MacVim "$DECRYPTED_FILE"
+# Wait for MacVim to close the file
+printf "${YELLOW}Waiting for MacVim to close...${NC}\n"
+# Get the initial modification time
+initial_mtime=$(stat -f "%m" "$DECRYPTED_FILE")
+current_mtime=$initial_mtime
+# Wait for the file to be modified and then closed
+while pgrep MacVim >/dev/null; do
+    # Check if the file has been modified
+    current_mtime=$(stat -f "%m" "$DECRYPTED_FILE")
+    if [[ "$current_mtime" != "$initial_mtime" ]]; then
+        # File has been modified, now wait for MacVim to close
+        break
+    fi
+    sleep 1
+done
+# If file was modified, wait for MacVim to fully close
+if [[ "$current_mtime" != "$initial_mtime" ]]; then
+    # Wait for the user to close MacVim
+    osascript -e 'tell application "MacVim" to quit'
+    # Give it a moment to complete saving
+    sleep 1
+fi
+# Re-encrypt the file
+if ! encrypt_file; then
+    error_print "Error: Failed to re-encrypt file." true
+fi
+# Cleanup and exit (will be called by trap)
+exit 0


### PR DESCRIPTION
This pull request includes several changes to the `ShellScripts` directory, primarily adding a new script for managing OTP secrets with Zsh, updating the menu options, and adding a clear screen command to the OTP generator script.

### New Script Addition:
* [`ShellScripts/ZshOtpManager.sh`](diffhunk://#diff-9ac970e333d590fcdae3f9b2d41109fcecb8d7cbebf20b6326b61e9c593f434fR1-R136): Added a new script for managing OTP secrets, including functions for encryption, decryption, and secure file handling.

### Menu Updates:
* [`ShellScripts/Crypm.sh`](diffhunk://#diff-830aa43dc2b910fe68d765948290aad7e7cf620ce1ddcaba72ee732e1ff5770bL47-R54): Updated the `menu` function to include new options for the Zsh OTP Manager and adjusted existing menu entries for clarity.
* [`ShellScripts/Crypm.sh`](diffhunk://#diff-830aa43dc2b910fe68d765948290aad7e7cf620ce1ddcaba72ee732e1ff5770bR39-R42): Added a new function `otpzshmgr` to call the Zsh OTP Manager script and updated the main loop to handle the new menu option. [[1]](diffhunk://#diff-830aa43dc2b910fe68d765948290aad7e7cf620ce1ddcaba72ee732e1ff5770bR39-R42) [[2]](diffhunk://#diff-830aa43dc2b910fe68d765948290aad7e7cf620ce1ddcaba72ee732e1ff5770bR92-R94)

### Minor Enhancements:
* [`ShellScripts/ZshOtpGenerator.sh`](diffhunk://#diff-9292af91a013a383e6b59daac67864369c8ce2568da338454eb5a65bda5f4520R307): Added a `clear` command to the startup sequence to enhance user experience.New Zsh OTP Manager used to update Encrypted Secrets File.