### PR TITLE
Update GitHub Links.txt

### DIFF
--- a/Html/GitHub Links.txt
+++ b/Html/GitHub Links.txt
@@ -1,19 +1,19 @@
 DOW_Inline.html
 GitHub - https://github.com/iAGorynT/Code-Snippets/blob/main/Html/DOW_Inline.html
-Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/c9365cf593426f821fb1458a45f19ffe3ce79077/Html/DOW_Inline.html
+Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/535f32eea070018dc98643abf8b92872874430d9/Html/DOW_Inline.html
 Dev - https://raw.githack.com/iAGorynT/Code-Snippets/main/Html/DOW_Inline.html
 
 DOW_Links.html
 GitHub - https://github.com/iAGorynT/Code-Snippets/blob/main/Html/DOW_Links.html
-Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/f26388c40d17cf1455785f46061785067562a6da/Html/DOW_Links.html
+Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/535f32eea070018dc98643abf8b92872874430d9/Html/DOW_Links.html
 Dev - https://raw.githack.com/iAGorynT/Code-Snippets/main/Html/DOW_Links.html
 
 script.js
 GitHub - https://github.com/iAGorynT/Code-Snippets/blob/main/Html/script.js
-Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/c9365cf593426f821fb1458a45f19ffe3ce79077/Html/script.js
+Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/535f32eea070018dc98643abf8b92872874430d9/Html/script.js
 Dev - https://raw.githack.com/iAGorynT/Code-Snippets/main/Html/script.js
 
 styles.css
 GitHub - https://github.com/iAGorynT/Code-Snippets/blob/main/Html/styles.css
-Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/55536ab46bec75fdbfbb1398de2ad35c86eb3ce9/Html/styles.css
+Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/535f32eea070018dc98643abf8b92872874430d9/Html/styles.css
 Dev - https://raw.githack.com/iAGorynT/Code-Snippets/main/Html/styles.css


### PR DESCRIPTION
This pull request updates the production URLs for several HTML files in the `Html/GitHub Links.txt` file. The changes ensure that the links point to the latest versions of the files.

* Updated production URL for `DOW_Inline.html` to point to the latest version.
* Updated production URL for `DOW_Links.html` to point to the latest version.
* Updated production URL for `script.js` to point to the latest version.
* Updated production URL for `styles.css` to point to the latest version.Created new links for Day of Week web apps.