### PR TITLE
Update GitHub Links.txt

### DIFF
--- a/Html/GitHub Links.txt
+++ b/Html/GitHub Links.txt
@@ -1,6 +1,6 @@
 DOW_Inline.html
 GitHub - https://github.com/iAGorynT/Code-Snippets/blob/main/Html/DOW_Inline.html
-Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/535f32eea070018dc98643abf8b92872874430d9/Html/DOW_Inline.html
+Prod - https://rawcdn.githack.com/iAGorynT/Code-Snippets/40903f5f4efb439c388069b66dbd558ef27c6847/Html/DOW_Inline.html
 Dev - https://raw.githack.com/iAGorynT/Code-Snippets/main/Html/DOW_Inline.html
 
 DOW_Links.html


### PR DESCRIPTION
This pull request includes a small change to the `Html/GitHub Links.txt` file. The change updates the production link for the `DOW_Inline.html` file to point to a new commit. 

* [`Html/GitHub Links.txt`](diffhunk://#diff-8a1d43af03a3cc2f9dc9572427b2a8fd6d3824d8aa47c3ab245f5112970fab8dL3-R3): Updated the production link for `DOW_Inline.html` to reflect the latest commit.Updated DOW_Inline Prod link.