### PR TITLE
Updated MacVim Colorscheme

### DIFF
--- a/DotFiles/.gvimrc
+++ b/DotFiles/.gvimrc
@@ -111,6 +111,11 @@ unlet s:cpo_save
 
 " macVim Custom Editor Settings
 
+" Set Default Theme
+if has("gui_running")
+  colorscheme mustang_vim_colorscheme_by_hcalves_d1mxd78
+endif
+
 " Set Default font
 " set guifont=Menlo:h14 - Original Default
 " set guifont=-monospace-:h14 - System Default

--- a/DotFiles/.vimrc
+++ b/DotFiles/.vimrc
@@ -71,7 +71,9 @@ nnoremap <C-p> :call ToggleCopilot()<CR>
 set number
 
 " Set default colorscheme
-colorscheme mustang_vim_colorscheme_by_hcalves_d1mxd78
+" Note:  Moved to .gvimrc to avoid conflicts when running mvim or vim
+" from the command line
+" colorscheme mustang_vim_colorscheme_by_hcalves_d1mxd78
 
 " NERDtree Like Setup
 " Disable the Netrw banner


### PR DESCRIPTION
This pull request includes changes to the Vim configuration files to improve the user experience by setting a default theme and avoiding conflicts between different Vim environments. The most important changes are:

Vim configuration improvements:

* [`DotFiles/.gvimrc`](diffhunk://#diff-b41ec6454b6000872132d8866bc0fa50a0e62e869a3c4505f702c9aca4c6106cR114-R118): Added a condition to set the default theme only when the GUI is running.
* [`DotFiles/.vimrc`](diffhunk://#diff-5246c1447550ffd065a9ac7bc4a3c68b3b0de72f3578f4117f7bc57ab5ddef44L74-R76): Removed the default theme setting to avoid conflicts when running Vim or MacVim from the command line.Moved to .gvimrc to avoid conflicts when running mvim or vim from the command line.