### PR TITLE
Update .vimrc

### DIFF
--- a/DotFiles/.vimrc
+++ b/DotFiles/.vimrc
@@ -72,6 +72,23 @@ imap <C-n> <Plug>(copilot-next)
 imap <C-p> <Plug>(copilot-previous)
 imap <C-d> <Plug>(copilot-dismiss)
 
+" Show Copilot keymaps
+function! ShowCopilotKeymaps()
+  redir => output
+  silent! imap
+  redir END
+  new
+  setlocal buftype=nofile bufhidden=wipe noswapfile
+  let filtered_lines = []
+  for line in split(output, "\n")
+    if line =~ "copilot"
+      call add(filtered_lines, line)
+    endif
+  endfor
+  call setline(1, filtered_lines)
+endfunction
+nnoremap <leader>kc :call ShowCopilotKeymaps()<CR>
+
 " Display line numbers in files
 set number
 


### PR DESCRIPTION
This pull request introduces a new function to display Copilot keymaps in the `DotFiles/.vimrc` file. The most important change includes adding a new function and a key mapping to show Copilot keymaps.

Enhancements to Copilot keymaps:

* [`DotFiles/.vimrc`](diffhunk://#diff-5246c1447550ffd065a9ac7bc4a3c68b3b0de72f3578f4117f7bc57ab5ddef44R75-R91): Added the `ShowCopilotKeymaps` function to filter and display Copilot-related key mappings in a new buffer. Also, added a key mapping (`<leader>kc`) to call this function.