### PR TITLE
Update Versions.sh

### DIFF
--- a/ShellScripts/Versions.sh
+++ b/ShellScripts/Versions.sh
@@ -81,8 +81,11 @@ latest_tag=$(curl -s https://api.github.com/repos/python/cpython/tags |
 	sort -V | 
 	tail -1)
 info_echo "Latest Python version for Mac: $latest_tag"
-python3 -m pip --version | sed 's/\(.*\)from.*/\1/'
 pyenv --version
+python3 -m pip --version | sed 's/\(.*\)from.*/\1/'
+echo
+info_echo "Pip Installed Packages"
+pip list --format=columns
 echo
 
 # Rosetta2


### PR DESCRIPTION
This pull request includes changes to the `ShellScripts/Versions.sh` file, primarily focusing on improving the output and readability of the script. The most important changes include reordering the `pip --version` command, adding a new section to list installed pip packages, and ensuring the output is formatted clearly.

Output and readability improvements:

* [`ShellScripts/Versions.sh`](diffhunk://#diff-c757b44e7efec469ae90b58ea680402c9be7e808307b193c65ed8c2611be85f8L84-R88): Reordered the `python3 -m pip --version` command to follow `pyenv --version` for better logical flow.
* [`ShellScripts/Versions.sh`](diffhunk://#diff-c757b44e7efec469ae90b58ea680402c9be7e808307b193c65ed8c2611be85f8L84-R88): Added a new section to list installed pip packages using `pip list --format=columns` for improved visibility of package information.
* Added Pip Installed Packages reporting.