### PR TITLE
Updated Brew App Listing

### DIFF
--- a/ShellScripts/Brewapps.sh
+++ b/ShellScripts/Brewapps.sh
@@ -29,8 +29,8 @@ contains_app() {
 
 # Temporary file to store brew command results
     temp_file=$(mktemp)
-# Run the command and store output in a temporary file
-    brew desc --eval-all $(brew list) | awk 'gsub(/^([^:]*?)\s*:\s*/,"&=")' | column -s "=" -t > $temp_file
+# Run the command and store output in a temporary file and redirect stderr to /dev/null to suppress errors
+    brew desc --eval-all $(brew list) 2>/dev/null | awk 'gsub(/^([^:]*?)\s*:\s*/,"&=")' | column -s "=" -t > $temp_file
 
 # Read file line by line and check for app names
 while IFS= read -r line; do

--- a/ShellScripts/Brewm.sh
+++ b/ShellScripts/Brewm.sh
@@ -46,8 +46,8 @@ function brewapps {
     clear
     format_echo "Brew App Listing..." "yellow" "bold"
     echo
-    # Formatted Listing
-    brew desc --eval-all $(brew list) | awk 'gsub(/^([^:]*?)\s*:\s*/,"&=")' | column -s "=" -t | more
+    # Formatted Listing and redirect stderr to /dev/null to suppress errors
+    brew desc --eval-all $(brew list) 2>/dev/null | awk 'gsub(/^([^:]*?)\s*:\s*/,"&=")' | column -s "=" -t | more
     # For Unformatted Listing
     # brew desc --eval-all $(brew list)
 }


### PR DESCRIPTION
This pull request introduces a minor change to suppress error messages in the output of `brew desc` commands by redirecting `stderr` to `/dev/null` in two shell scripts. This improves the user experience by preventing unnecessary error messages from being displayed.

Changes to error handling:

* [`ShellScripts/Brewapps.sh`](diffhunk://#diff-af61a44818798f97c100abbf8c1131b4aaae42bac786868e439135ff652a0600L32-R33): Updated the `contains_app()` function to redirect `stderr` to `/dev/null` when running the `brew desc` command.
* [`ShellScripts/Brewm.sh`](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L49-R50): Updated the `brewapps` function to redirect `stderr` to `/dev/null` when running the `brew desc` command.
* Redirect stderr to /dev/null to supress errors / warnings.