### PR TITLE
Claude Workspace

### DIFF
--- a/ShellScripts/CleanupClaude.sh
+++ b/ShellScripts/CleanupClaude.sh
@@ -1,0 +1,91 @@
+#!/bin/zsh
+
+# Zsh script to remove contents of all folders in claude_workspace
+# This script will preserve the folder structure but remove all files within subdirectories
+
+# Source function library with error handling
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+if [[ ! -f "$FORMAT_LIBRARY" ]]; then
+    printf "Error: Required library %s not found\n" "$FORMAT_LIBRARY" >&2
+    exit 1
+fi
+source "$FORMAT_LIBRARY"
+
+WORKSPACE_DIR="$HOME/Desktop/claude_workspace"
+
+info_printf "Starting cleanup of folder contents in claude_workspace..."
+
+# Function to display script header
+display_header() {
+    clear
+    format_printf "Cleanup Claude Workspace..." "yellow" "bold"
+    printf "\n"
+}
+
+# Function to prompt for confirmation
+confirm_deletion() {
+    warning_printf "This will remove ALL contents from the following directories:"
+    find "$WORKSPACE_DIR" -mindepth 1 -maxdepth 1 -type d | while read -r folder; do
+        format_printf "  • $(basename "$folder")/" "blue" "bold"
+        if [ -n "$(find "$folder" -mindepth 1 2>/dev/null)" ]; then
+            format_printf "    Contains files that will be deleted" "red"
+        else
+            format_printf "    Already empty" "green"
+        fi
+    done
+    
+    printf "\n"
+    error_printf "WARNING: This action cannot be undone!"
+    # Use direct printf with color formatting to keep input on same line
+    printf '\033[1;33m%s\033[0m' "Do you want to continue? (y/N): "
+    
+    read -r response
+    case "$response" in
+        [yY]|[yY][eE][sS])
+            return 0
+            ;;
+        *)
+            error_printf "Claude Cleanup cancelled by user."
+            exit 0
+            ;;
+    esac
+}
+
+# Function to clear contents of a directory
+clear_directory_contents() {
+    local dir="$1"
+    if [ -d "$dir" ]; then
+        info_printf "Clearing contents of: $dir"
+        # Remove all files and subdirectories within the directory
+        find "$dir" -mindepth 1 -delete 2>/dev/null
+        if [ $? -eq 0 ]; then
+            success_printf "Cleared: $dir"
+        else
+            error_printf "Failed to clear: $dir"
+        fi
+    fi
+}
+
+# Check if workspace directory exists
+if [ ! -d "$WORKSPACE_DIR" ]; then
+    error_printf "claude_workspace directory not found at $WORKSPACE_DIR" true
+fi
+
+# Display the header
+display_header
+
+# Prompt for confirmation before proceeding
+confirm_deletion
+
+# Find all directories in claude_workspace (excluding the workspace directory itself)
+find "$WORKSPACE_DIR" -mindepth 1 -maxdepth 1 -type d | while read -r folder; do
+    clear_directory_contents "$folder"
+done
+
+success_printf "Folder contents cleanup completed!"
+
+# Show the current structure
+printf "\n"
+info_printf "Current folder structure:"
+tree "$WORKSPACE_DIR" 2>/dev/null || find "$WORKSPACE_DIR" -type d | sed 's|[^/]*/|  |g'
+

--- a/ShellScripts/Utilm.sh
+++ b/ShellScripts/Utilm.sh
@@ -22,6 +22,11 @@ function cleanup {
     Cleanup.sh
 }
 
+function cleanupclaude {
+    clear
+    CleanupClaude.sh
+}
+
 function menu {
     clear
     echo
@@ -30,6 +35,7 @@ function menu {
     echo -e "\t2. Pip Package Update"
     echo -e "\t3. Vim Plugin Update"
     echo -e "\t4. Disk Cleanup"
+    echo -e "\t5. Cleanup Claude Workspace"
     echo -e "\t0. Exit Menu\n\n"
     echo -en "\t\tEnter an Option: "
     # Read entire input instead of just one character
@@ -60,6 +66,10 @@ while true; do
                 ;;
             4)
                 cleanup
+                hit_any_key=true
+                ;;
+            5)
+                cleanupclaude
                 hit_any_key=true
                 ;;
             *)

--- a/ShellScripts/zJump.sh
+++ b/ShellScripts/zJump.sh
@@ -43,7 +43,7 @@ zjump() {
 
     # Change directory and show confirmation
     if [[ -n "$target_dir" ]]; then
-        cd "$target_dir" && print -P "%F{green}Changed to:%f $target_dir"
+        cd "$target_dir" && clear && print -P "%F{green}Changed to:%f $target_dir" && echo && ls -a
     fi
 }
 


### PR DESCRIPTION
This pull request introduces a new script for cleaning up the `claude_workspace` directory, integrates it into the existing utility menu, and makes a minor enhancement to the `zjump` function. Below are the most important changes grouped by theme:

### New Script Addition:
* Added `CleanupClaude.sh`, a Zsh script to remove all files within subdirectories of `claude_workspace` while preserving the folder structure. The script includes error handling, user confirmation, and displays the current folder structure after cleanup.

### Integration into Utility Menu:
* Added a new `cleanupclaude` function in `Utilm.sh` to invoke the `CleanupClaude.sh` script.
* Updated the `menu` function in `Utilm.sh` to include "Cleanup Claude Workspace" as option 5 in the utility menu.
* Updated the menu selection logic in `Utilm.sh` to handle option 5 for executing the `cleanupclaude` function.

### Minor Enhancement:
* Enhanced the `zjump` function in `zJump.sh` to clear the terminal and display the contents of the target directory after changing to it.Implement Claude integration into dev workflow.  Improve zJump folder contents listing.