### PR TITLE
Update .zshrc

### DIFF
--- a/DotFiles/.zshrc
+++ b/DotFiles/.zshrc
@@ -183,6 +183,9 @@ export FZF_CTRL_T_OPTS="--preview 'bat --style=numbers --color=always --line-ran
 # ALT+C stays for directory search
 export FZF_ALT_C_COMMAND="fd . --type d --hidden --no-ignore --exclude .git --exclude node_modules $HOME/bin $HOME/bin/zTests $HOME/PythonCode $HOME/.logs $HOME/Downloads $HOME/Documents"
 
+# Disable priview and clean up layout for ALT+C
+export FZF_ALT_C_OPTS="--no-preview --layout=reverse --height=40%"
+
 # Source fzf
 source <(fzf --zsh)
 


### PR DESCRIPTION
This pull request makes a small update to the `DotFiles/.zshrc` file to improve the usability of the `ALT+C` directory search functionality by disabling the preview and adjusting the layout.

* [`DotFiles/.zshrc`](diffhunk://#diff-18e452e987538d0759110508659963c35ef0ec1cf4c49d20884ea882be3b215bR186-R188): Added `FZF_ALT_C_OPTS` to disable the preview and set a reverse layout with a height of 40% for the `ALT+C` directory search.Removed bat preview from fzf Alt-C (change directory) keyboard command.