### PR TITLE
Update BrewAppUninstall.sh

### DIFF
--- a/ShellScripts/BrewAppUninstall.sh
+++ b/ShellScripts/BrewAppUninstall.sh
@@ -4,39 +4,36 @@
 # This script provides an interactive menu to uninstall Homebrew packages (formulae and casks).
 
 # Source function library with error handling
-FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatEcho.sh"
-if [[ ! -f "$FORMAT_LIBRARY" ]]; then
-    echo "Error: Required library $FORMAT_LIBRARY not found" >&2
-    exit 1
-fi
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library %s not found\n" "$FORMAT_LIBRARY" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
 # Function to display menu
 function show_menu() {
     local i=1
     for package in "$@"; do
-        echo "$i) $package"
+        printf "%d) %s\n" "$i" "$package"
         ((i++))
     done
-    echo "0) Exit"
-    echo
+    printf "0) Exit\n"
+    printf "\n"
 }
 
 # Function to fetch installed packages
 function fetch_packages() {
-    info_echo "Fetching installed formulae..."
+    info_printf "Fetching installed formulae..."
     formulae=($(brew list --formula))
-    info_echo "Fetching installed casks..."
+    info_printf "Fetching installed casks..."
     casks=($(brew list --cask))
     all_packages=("${formulae[@]}" "${casks[@]}")
 }
 
 # Function to display package counts
 function show_package_counts() {
-    echo "Number of formulae: ${#formulae[@]}"
-    echo "Number of casks: ${#casks[@]}"
-    echo "Total number of packages: ${#all_packages[@]}"
-    echo
+    printf "Number of formulae: %d\n" "${#formulae[@]}"
+    printf "Number of casks: %d\n" "${#casks[@]}"
+    printf "Total number of packages: %d\n" "${#all_packages[@]}"
+    printf "\n"
 }
 
 # Function to uninstall a package
@@ -48,14 +45,14 @@ function uninstall_package() {
         brew uninstall "$package"
     fi
     brew autoremove
-    echo "$package has been uninstalled."
+    printf "%s has been uninstalled.\n" "$package"
     all_packages=("${(@)all_packages:#$package}")
 }
 
 # Main script
 clear
-format_echo "Brew App Uninstaller..." "yellow" "bold"
-echo
+format_printf "Brew App Uninstaller..." "yellow" "bold"
+printf "\n"
 
 # Initialize package lists
 fetch_packages
@@ -64,11 +61,11 @@ show_package_counts
 # Main loop
 while true; do
     if [ ${#all_packages[@]} -eq 0 ]; then
-        echo "No Homebrew packages found. Exiting."
+        printf "No Homebrew packages found. Exiting.\n"
         exit 0
     fi
 
-    info_echo "Installed Homebrew packages:"
+    info_printf "Installed Homebrew packages:"
     show_menu "${all_packages[@]}"
 
     read "choice?Enter the number of the package you want to uninstall (0 to exit): "
@@ -76,7 +73,7 @@ while true; do
 
     if [[ $choice =~ ^[0-9]+$ ]]; then
         if (( choice == 0 )); then
-            info_echo "Exiting. No packages were uninstalled."
+            info_printf "Exiting. No packages were uninstalled."
             exit 0
         elif (( choice <= ${#all_packages[@]} )); then
             selected_package=${all_packages[$choice]}
@@ -85,23 +82,23 @@ while true; do
             if [[ $confirm =~ ^[Yy]$ ]]; then
                 uninstall_package "$selected_package"
             else
-                echo "Uninstallation cancelled."
+                printf "Uninstallation cancelled.\n"
             fi
         else
-            echo "Invalid selection. Please enter a number between 0 and ${#all_packages[@]}."
+            printf "Invalid selection. Please enter a number between 0 and %d.\n" "${#all_packages[@]}"
         fi
     else
-        echo "Invalid input. Please enter a number."
+        printf "Invalid input. Please enter a number.\n"
     fi
 
-    echo
+    printf "\n"
     read "continue?Press Enter to continue or type 'exit' to quit: "
     if [[ $continue == "exit" ]]; then
-        echo "Exiting. Brew App Uninstaller completed."
+        printf "Exiting. Brew App Uninstaller completed.\n"
         exit 0
     else
         clear
-        echo
+        printf "\n"
     fi
 done
 


### PR DESCRIPTION
This pull request refactors the `ShellScripts/BrewAppUninstall.sh` script to replace `echo` statements with `printf` for improved formatting and consistency. Additionally, it updates the script to use a new format library and enhances error handling.

### Refactoring for Consistency and Formatting:
* Replaced all `echo` statements with `printf` to standardize output formatting and improve flexibility. This change affects functions such as `show_menu`, `fetch_packages`, `show_package_counts`, and others. [[1]](diffhunk://#diff-26550951c6dc304aa1d04580b2ffc6bb078c4cc26f4247663a5705ad01d342b3L7-R36) [[2]](diffhunk://#diff-26550951c6dc304aa1d04580b2ffc6bb078c4cc26f4247663a5705ad01d342b3L51-R55) [[3]](diffhunk://#diff-26550951c6dc304aa1d04580b2ffc6bb078c4cc26f4247663a5705ad01d342b3L67-R76) [[4]](diffhunk://#diff-26550951c6dc304aa1d04580b2ffc6bb078c4cc26f4247663a5705ad01d342b3L88-R101)

### Library Update:
* Updated the format library from `FLibFormatEcho.sh` to `FLibFormatPrintf.sh`, and improved error handling for loading the library.Updated to use FLibFormatPrintf.sh function to improve formatting and reporting of information.