### PR TITLE
Converted to FLibFormatPrintf.sh

### DIFF
--- a/ShellScripts/Brewdocm.sh
+++ b/ShellScripts/Brewdocm.sh
@@ -4,41 +4,38 @@
 trap 'echo -e  "\nCtrl-C will not terminate $0."'  INT
 
 # Source function library with error handling
-FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatEcho.sh"
-if [[ ! -f "$FORMAT_LIBRARY" ]]; then
-    echo "Error: Required library $FORMAT_LIBRARY not found" >&2
-    exit 1
-fi
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { echo "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
 function brewdocs1 {
 	clear
-	format_echo "HomeBrew Update 1/3..." "none" "brew"
+	format_printf "HomeBrew Update 1/3..." "none" "brew"
 	echo " "
 	brew update
 	echo " "
-	info_echo "Fix any errors and continue with Step 2"
-	info_echo "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
+	info_printf "Fix any errors and continue with Step 2"
+	info_printf "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
 }
 
 function brewdocs2 {
 	clear
-	format_echo "HomeBrew Update 2/3..." "none" "brew"
+	format_printf "HomeBrew Update 2/3..." "none" "brew"
 	echo " "
 	brew update
 	echo " "
-	info_echo "Fix any errors and continue with Step 3"
-	info_echo "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
+	info_printf "Fix any errors and continue with Step 3"
+	info_printf "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
 }
 
 function brewdocs3 {
 	clear
-	format_echo "Brew Doctor 3/3..." "none" "brew"
+	format_printf "Brew Doctor 3/3..." "none" "brew"
 	echo " "
 	brew doctor
 	echo " "
-	info_echo "Fix any errors to complete Brew Doctor Recovery"
-	info_echo "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
+	info_printf "Fix any errors to complete Brew Doctor Recovery"
+	info_printf "cmd-doubleclick for troubleshooting info: https://docs.brew.sh/Troubleshooting"
 }
 
 function menu {

--- a/ShellScripts/Brewit.sh
+++ b/ShellScripts/Brewit.sh
@@ -3,66 +3,63 @@
 # Update BrewitLaunchd.sh with changes when necessary.
 
 # Source function library with error handling
-FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatEcho.sh"
-if [[ ! -f "$FORMAT_LIBRARY" ]]; then
-    echo "Error: Required library $FORMAT_LIBRARY not found" >&2
-    exit 1
-fi
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library %s not found\n" "$FORMAT_LIBRARY" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
 clear
-format_echo "Brew Update, Upgrade, and Cleanup..." "yellow" "bold"
-echo " "
+format_printf "Brew Update, Upgrade, and Cleanup..." "yellow" "bold"
+printf "\n"
 
 # HomeBrew Update
-format_echo "HomeBrew Update..." "none" "brew"
-echo " "
+format_printf "HomeBrew Update..." "none" "brew"
+printf "\n"
 brew update
 brew upgrade
 
 # Cask Upgrade
-format_echo "Cask Upgrade..." "none" "brew"
-echo " "
+format_printf "Cask Upgrade..." "none" "brew"
+printf "\n"
 brew upgrade --cask --greedy
 
 # Create temporary Brewfile
-format_echo "Creating temporary Brewfile..." "none" "brew"
-echo " "
+format_printf "Creating temporary Brewfile..." "none" "brew"
+printf "\n"
 cd
 brew bundle dump --file=Brewfile.new
 
 # Check if previous Brewfile exists
 if [[ -f Brewfile ]]; then
-    format_echo "Comparing with existing Brewfile..." "none" "brew"
+    format_printf "Comparing with existing Brewfile..." "none" "brew"
     
     # Compare files, ignoring whitespace
     if diff -w Brewfile Brewfile.new > /dev/null; then
-        format_echo "No changes detected. Keeping existing Brewfile." "none" "brew"
+        format_printf "No changes detected. Keeping existing Brewfile." "none" "brew"
         rm Brewfile.new
     else
-        format_echo "Changes detected. Updating Brewfile..." "none" "brew"
+        format_printf "Changes detected. Updating Brewfile..." "none" "brew"
         mv Brewfile Brewfile.backup
         mv Brewfile.new Brewfile
         chmod 644 Brewfile
-        echo "Backup of previous Brewfile created as: Brewfile.backup"
+        printf "Backup of previous Brewfile created as: Brewfile.backup\n"
     fi
 else
-    format_echo "No existing Brewfile found. Creating new one..." "none" "brew"
+    format_printf "No existing Brewfile found. Creating new one..." "none" "brew"
     mv Brewfile.new Brewfile
     chmod 644 Brewfile
 fi
 
-echo "Current Brewfile location: $(pwd)"
+printf "Current Brewfile location: %s\n" "$(pwd)"
 ls -al Brewfile
-echo " "
+printf "\n"
 
 # HomeBrew Cleanup
-format_echo "HomeBrew Cleanup..." "none" "brew"
-echo " "
+format_printf "HomeBrew Cleanup..." "none" "brew"
+printf "\n"
 brew autoremove
 brew cleanup
 brew list
 
-echo " "
-success_echo "Brew Update, Upgrade, and Cleanup Completed!"
-echo " "
+printf "\n"
+success_printf "Brew Update, Upgrade, and Cleanup Completed!"
+printf "\n"


### PR DESCRIPTION
This pull request updates two shell scripts to replace the `format_echo` and `info_echo` functions with their `format_printf` and `info_printf` counterparts, improving formatting consistency and error handling. Additionally, the error handling for sourcing the function library has been streamlined.

### Functionality updates:

* Replaced `format_echo` and `info_echo` with `format_printf` and `info_printf` across `ShellScripts/Brewdocm.sh` and `ShellScripts/Brewit.sh` for consistent formatting and improved readability. [[1]](diffhunk://#diff-765531b3e9e58faa949d62f2ba67862f6b04739ccff75b871741eadf2265fb7eL7-R38) [[2]](diffhunk://#diff-3df39ac376779f18eed6d58fd47533fdb2f349c91b235dcbd2f2fdfcb8c5a3a2L6-R65)

### Error handling improvements:

* Updated the error handling for sourcing the function library to use concise conditional expressions, replacing `if` blocks with `||` operators for better readability and reduced code duplication. [[1]](diffhunk://#diff-765531b3e9e58faa949d62f2ba67862f6b04739ccff75b871741eadf2265fb7eL7-R38) [[2]](diffhunk://#diff-3df39ac376779f18eed6d58fd47533fdb2f349c91b235dcbd2f2fdfcb8c5a3a2L6-R65)Standardized reporting and message formatting.