### PR TITLE
Upgrade to FLibFormatPrintf

### DIFF
--- a/ShellScripts/BrewautoInstaller.sh
+++ b/ShellScripts/BrewautoInstaller.sh
@@ -72,7 +72,7 @@ fi
 
 # Download bin files
 cd "$BIN_FOLDER" || exit 1
-for file in Brewautom2.sh BrewitLaunchd.sh FLibFormatEcho.sh; do
+for file in Brewautom2.sh BrewitLaunchd.sh FLibFormatPrintf.sh; do
     download_github_file "bin/$file" "$BIN_FOLDER"
     display_message $?
     printf "\n"

--- a/ShellScripts/BrewitLaunchd.sh
+++ b/ShellScripts/BrewitLaunchd.sh
@@ -5,68 +5,65 @@
 # When changes are made, be sure to Unload / Load new file into Launchd
 
 # Source function library with error handling
-FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatEcho.sh"
-if [[ ! -f "$FORMAT_LIBRARY" ]]; then
-    echo "Error: Required library $FORMAT_LIBRARY not found" >&2
-    exit 1
-fi
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library %s not found\n" "$FORMAT_LIBRARY" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
-echo "Brew Update, Upgrade, and Cleanup..."
-echo $(date)
-echo " "
+format_printf "Brew Update, Upgrade, and Cleanup..."
+format_printf "$(date)"
+printf "\n"
 
 # HomeBrew Update
-format_echo "HomeBrew Update..." "none" "brewl"
-echo " "
+format_printf "HomeBrew Update..." "none" "brewl"
+printf "\n"
 brew update
 brew upgrade
 
 # Cask Upgrade
-format_echo "Cask Upgrade..." "none" "brewl"
-echo " "
+format_printf "Cask Upgrade..." "none" "brewl"
+printf "\n"
 brew upgrade --cask --greedy
 
 # Create temporary Brewfile
-format_echo "Creating temporary Brewfile..." "none" "brewl"
-echo " "
+format_printf "Creating temporary Brewfile..." "none" "brewl"
+printf "\n"
 cd
 brew bundle dump --file=Brewfile.new
 
 # Check if previous Brewfile exists
 if [[ -f Brewfile ]]; then
-    format_echo "Comparing with existing Brewfile..." "none" "brewl"
+    format_printf "Comparing with existing Brewfile..." "none" "brewl"
     
     # Compare files, ignoring whitespace
     if diff -w Brewfile Brewfile.new > /dev/null; then
-        format_echo "No changes detected. Keeping existing Brewfile." "none" "brewl"
+        format_printf "No changes detected. Keeping existing Brewfile." "none" "brewl"
         rm Brewfile.new
     else
-        format_echo "Changes detected. Updating Brewfile..." "none" "brewl"
+        format_printf "Changes detected. Updating Brewfile..." "none" "brewl"
         mv Brewfile Brewfile.backup
         mv Brewfile.new Brewfile
         chmod 644 Brewfile
-        echo "Backup of previous Brewfile created as: Brewfile.backup"
+        format_printf "Backup of previous Brewfile created as: Brewfile.backup"
     fi
 else
-    format_echo "No existing Brewfile found. Creating new one..." "none" "brewl"
+    format_printf "No existing Brewfile found. Creating new one..." "none" "brewl"
     mv Brewfile.new Brewfile
     chmod 644 Brewfile
 fi
 
-echo "Current Brewfile location: $(pwd)"
+format_printf "Current Brewfile location: $(pwd)"
 ls -al Brewfile
-echo " "
+printf "\n"
 
 # HomeBrew Cleanup
-format_echo "HomeBrew Cleanup..." "none" "brewl"
-echo " "
+format_printf "HomeBrew Cleanup..." "none" "brewl"
+printf "\n"
 brew autoremove
 brew cleanup
-echo " "
-format_echo "Installed Apps..." "none" "brewl"
+printf "\n"
+format_printf "Installed Apps..." "none" "brewl"
 brew list -1
 
-echo " "
-echo "Brew Update, Upgrade, and Cleanup Completed!"
-echo " "
+printf "\n"
+format_printf "Brew Update, Upgrade, and Cleanup Completed!"
+printf "\n"

--- a/ShellScripts/Brewm.sh
+++ b/ShellScripts/Brewm.sh
@@ -1,13 +1,10 @@
 #!/bin/zsh
 # Trap Ctl-C and Require a Menu Selection to Exit Script
-trap 'echo -e  "\nCtrl-C will not terminate $0."'  INT
+trap 'printf "\nCtrl-C will not terminate %s.\n" "$0"'  INT
 
 # Source function library with error handling
-FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatEcho.sh"
-if [[ ! -f "$FORMAT_LIBRARY" ]]; then
-    echo "Error: Required library $FORMAT_LIBRARY not found" >&2
-    exit 1
-fi
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library %s not found\n" "$FORMAT_LIBRARY" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
 function brewit {
@@ -17,25 +14,25 @@ function brewit {
 
 function brewlist {
     clear
-    format_echo "Brew List..." "yellow" "bold"
-    echo
+    format_printf "Brew List..." "yellow" "bold"
+    printf "\n"
     brew list
 }
 
 function brewdep {
     clear
-    format_echo "Brew Dependencies..." "yellow" "bold"
-    echo
+    format_printf "Brew Dependencies..." "yellow" "bold"
+    printf "\n"
     brew deps --formula --installed | more
 }
 
 function viewbrewfile {
     # Display Brew File Contents
     clear
-    format_echo "Brew File..." "yellow" "bold"
-    echo
+    format_printf "Brew File..." "yellow" "bold"
+    printf "\n"
     cat ~/Brewfile
-    echo -en "\n\n\t\t\tHit any key to view App Descriptions"
+    printf "\n\n\t\t\tHit any key to view App Descriptions"
     read -k 1 line
     # Display Selected Brew File App Descriptions
     clear
@@ -44,8 +41,8 @@ function viewbrewfile {
 
 function brewapps {
     clear
-    format_echo "Brew App Listing..." "yellow" "bold"
-    echo
+    format_printf "Brew App Listing..." "yellow" "bold"
+    printf "\n"
     # Formatted Listing and redirect stderr to /dev/null to suppress errors
     brew desc --eval-all $(brew list) 2>/dev/null | awk 'gsub(/^([^:]*?)\s*:\s*/,"&=")' | column -s "=" -t | more
     # For Unformatted Listing
@@ -54,10 +51,10 @@ function brewapps {
 
 function brewtap {
     clear
-    format_echo "Brew Taps..." "yellow" "bold"
-    info_echo "Directories (usually Git Repositories) of formulae (CLI based Apps),"
-    info_echo "Casks (GUI based Apps), and/or external commands."
-    echo
+    format_printf "Brew Taps..." "yellow" "bold"
+    info_printf "Directories (usually Git Repositories) of formulae (CLI based Apps),"
+    info_printf "Casks (GUI based Apps), and/or external commands."
+    printf "\n"
     brew tap
 }
 
@@ -83,24 +80,24 @@ function brewappuninstaller {
 
 function menu {
     clear
-    echo
-    echo -e "\t\t\t\033[33;1mHomeBrew Menu\033[0m\n"
-    echo -e "\t1. Brewit"
-    echo -e "\t2. Brew List"
-    echo -e "\t3. Brew Dependencies"
-    echo -e "\t4. View Brewfile"
-    echo -e "\t5. Brew App Listing"
-    echo -e "\t6. Brew Taps"
-    echo -e "\t7. Brew Doctor"
-    echo -e "\t8. Brew Autoupdate"
-    echo -e "\t9. MacVim Explore"
-    echo -e "\t10. Brew App Uninstaller"
-    echo -e "\t0. Exit Menu\n\n"
-    echo -en "\t\tEnter an Option: "
+    printf "\n"
+    printf "\t\t\t\033[33;1mHomeBrew Menu\033[0m\n\n"
+    printf "\t1. Brewit\n"
+    printf "\t2. Brew List\n"
+    printf "\t3. Brew Dependencies\n"
+    printf "\t4. View Brewfile\n"
+    printf "\t5. Brew App Listing\n"
+    printf "\t6. Brew Taps\n"
+    printf "\t7. Brew Doctor\n"
+    printf "\t8. Brew Autoupdate\n"
+    printf "\t9. MacVim Explore\n"
+    printf "\t10. Brew App Uninstaller\n"
+    printf "\t0. Exit Menu\n\n\n"
+    printf "\t\tEnter an Option: "
     # Read entire input instead of just one character
     read option
     # Remove any whitespace
-    option=$(echo $option | tr -d '[:space:]')
+    option=$(printf %s "$option" | tr -d '[:space:]')
 }
 
 # Main loop
@@ -153,7 +150,7 @@ while true; do
                 ;;
             *)
                 clear
-                echo "Sorry, wrong selection"
+                printf "Sorry, wrong selection\n"
                 hit_any_key=true
                 ;;
         esac
@@ -162,12 +159,12 @@ while true; do
         break
     else
         clear
-        echo "Please enter a valid number"
+        printf "Please enter a valid number\n"
         hit_any_key=true
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        printf "\n\n\t\t\tHit any key to continue"
         read -k 1 line
     fi
 done


### PR DESCRIPTION
This pull request updates several shell scripts to replace the `FLibFormatEcho.sh` library with `FLibFormatPrintf.sh` and transitions from `echo` commands to `printf` for improved formatting and consistency. Additionally, some minor code improvements and error handling enhancements were made.

### Library Replacement and Formatting Updates:
* [`ShellScripts/BrewautoInstaller.sh`](diffhunk://#diff-aa552a1c56fe7ab51667eedc7a0db7de99636999830ffa3bc3ab69a32b6c589dL75-R75): Updated the loop to download `FLibFormatPrintf.sh` instead of `FLibFormatEcho.sh`.
* [`ShellScripts/BrewitLaunchd.sh`](diffhunk://#diff-0072b7ae42e5725d089f05551814c02e157ca45d974af6855c32524a5f5910cdL8-R69): Replaced `FLibFormatEcho.sh` with `FLibFormatPrintf.sh` and updated all `echo` calls to use `format_printf` for consistent formatted output.
* [`ShellScripts/Brewm.sh`](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L3-R7): Replaced `FLibFormatEcho.sh` with `FLibFormatPrintf.sh` and transitioned all `echo` calls to `format_printf` or `printf` for improved formatting and error handling.

### Code Improvements:
* [`ShellScripts/Brewm.sh`](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L86-R100): Updated the menu display logic to use `printf` for cleaner and more consistent output.
* [`ShellScripts/Brewm.sh`](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L156-R153): Enhanced error messages and prompts to use `printf` for better readability. [[1]](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L156-R153) [[2]](diffhunk://#diff-8701f6819914d43cac93098e592d7fbd2324a438e2a899c1f67fe2a4194eb8f5L165-R167)Standardize reporting and messages in scripts.