### PR TITLE
Update PyUpdate.sh

### DIFF
--- a/ShellScripts/PyUpdate.sh
+++ b/ShellScripts/PyUpdate.sh
@@ -64,11 +64,11 @@ printf "\n"
 if [[ "$current_python" == "$latest_python" ]]; then
     success_printf "Python is up to date"
 else
-    info_printf "Python is not up to date"
+    warning_printf "Python is not up to date"
     printf "\n"
     
     # Check if pyenv is up-to-date with the latest Python version
-    major_version=$(echo "$latest_python" | sed 's/^\([0-9]\+\)\..*/\1/')
+    major_version=$(echo "$latest_python" | cut -d'.' -f1)
     pyenv_latest=$(pyenv latest "$major_version" 2>/dev/null || echo "")
     
     if [[ -z "$pyenv_latest" ]] || [[ "$pyenv_latest" != "$latest_python" ]]; then


### PR DESCRIPTION
This pull request updates the `ShellScripts/PyUpdate.sh` script to improve clarity and functionality. The changes include modifying the message format for outdated Python versions and simplifying the extraction of the major version number.

Updates to message format:

* Replaced `info_printf` with `warning_printf` to indicate that Python is not up to date more prominently. (`[ShellScripts/PyUpdate.shL67-R71](diffhunk://#diff-af24a47319973a43763d41ff3f7ed6d482807a1eac3e5a68653c5f39497f057bL67-R71)`)

Simplification of version extraction:

* Changed the method for extracting the major version number of Python from `sed` to `cut`, making the code simpler and more readable. (`[ShellScripts/PyUpdate.shL67-R71](diffhunk://#diff-af24a47319973a43763d41ff3f7ed6d482807a1eac3e5a68653c5f39497f057bL67-R71)`)Bug fix:  major_version initialization