### PR TITLE
Standardize prompt to 'Hit any key to continue'

### DIFF
--- a/ShellScripts/BrewAppUninstall.sh
+++ b/ShellScripts/BrewAppUninstall.sh
@@ -92,7 +92,7 @@ while true; do
     fi
 
     printf "\n"
-    read "continue?Press Enter to continue or type 'exit' to quit: "
+    read "continue?Hit any key to continue or type 'exit' to quit: "
     if [[ $continue == "exit" ]]; then
         printf "Exiting. Brew App Uninstaller completed.\n"
         exit 0

--- a/ShellScripts/Brewautom2.sh
+++ b/ShellScripts/Brewautom2.sh
@@ -93,7 +93,7 @@ function autoupdate_status() {
             minutes=$(printf "%02d" "$minutes")
             echo "Runs Daily: ${hour}:${minutes}"
         fi 
-        echo -en "\n\n\t\t\tPress any key to view the Autoupdate Log"
+        echo -en "\n\n\t\t\tHit any key to view the Autoupdate Log"
         read -k 1
         clear
         print_status "${COLOR_BLUE}" "Brew Autoupdate Log Listing..."
@@ -264,7 +264,7 @@ while true; do
         clear
         print_status "${COLOR_RED}" "\n\tPlease enter a valid number"
     fi
-    echo -en "\n\tPress any key to continue"
+    echo -en "\n\tHit any key to continue"
     read -k 1
 done
 

--- a/ShellScripts/Crypvault.sh
+++ b/ShellScripts/Crypvault.sh
@@ -273,6 +273,6 @@ while true; do
 
     # Pause before next iteration
     printf "\n"
-    printf "Press any key to continue..."
+    printf "Hit any key to continue"
     read -k 1
 done

--- a/ShellScripts/GauthMgr.sh
+++ b/ShellScripts/GauthMgr.sh
@@ -132,7 +132,7 @@ process_operation() {
             printf "\n\n"
             cat "$DECRYPTED_FILE"
             printf "\n"
-            read -r "?Press Enter to continue..."
+            read -r "?Hit any key to continue"
             ;;
         *)
             error_printf "Unknown operation: $operation" true


### PR DESCRIPTION
Updated user prompts in multiple shell scripts to consistently use 'Hit any key to continue' instead of variations like 'Press any key to continue' or 'Press Enter to continue'. This improves clarity and consistency across BrewAppUninstall.sh, Brewautom2.sh, Crypvault.sh, and GauthMgr.sh.