### PR TITLE
Replace 'Hit any key' with 'Press any key' in scripts

### DIFF
--- a/ShellScripts/Aliasdoc.sh
+++ b/ShellScripts/Aliasdoc.sh
@@ -77,12 +77,12 @@ while true; do
                 fi
             fi
         done < "$zshrcfile"
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     else
 # Handle Invalid Input
         echo -e '\n\t\t\t\e[1mInvalid choice\e[0m'
-        echo -en "\n\t\t\tHit any key to continue"
+        echo -en "\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 # Display Main Menu

--- a/ShellScripts/BrewAppUninstall.sh
+++ b/ShellScripts/BrewAppUninstall.sh
@@ -92,7 +92,7 @@ while true; do
     fi
 
     printf "\n"
-    read "continue?Hit any key to continue or type 'exit' to quit: "
+    read "continue?Press any key to continue or type 'exit' to quit: "
     if [[ $continue == "exit" ]]; then
         printf "Exiting. Brew App Uninstaller completed.\n"
         exit 0

--- a/ShellScripts/Brewautom.sh
+++ b/ShellScripts/Brewautom.sh
@@ -19,7 +19,7 @@ function autoupdatestatus {
 	fi
 # Check if the Autoupdate Log file exists
 	if [ -f "$autolog" ]; then
-	    echo -en "\n\n\t\t\tHit any key to view Autoupdate Log Listing"
+	    echo -en "\n\n\t\t\tPress any key to view Autoupdate Log Listing"
 	    read -k 1 line
 	    clear
 	    echo "Brew Autoupdate Log Listing..."
@@ -142,7 +142,7 @@ do
 	clear
 	echo "Sorry, wrong selection";;
 	esac
-	echo -en "\n\n\t\t\tHit any key to continue"
+	echo -en "\n\n\t\t\tPress any key to continue"
 	read -k 1 line
 done
 clear

--- a/ShellScripts/Brewautom2.sh
+++ b/ShellScripts/Brewautom2.sh
@@ -93,7 +93,7 @@ function autoupdate_status() {
             minutes=$(printf "%02d" "$minutes")
             echo "Runs Daily: ${hour}:${minutes}"
         fi 
-        echo -en "\n\n\t\t\tHit any key to view the Autoupdate Log"
+        echo -en "\n\n\t\t\tPress any key to view the Autoupdate Log"
         read -k 1
         clear
         print_status "${COLOR_BLUE}" "Brew Autoupdate Log Listing..."
@@ -264,7 +264,7 @@ while true; do
         clear
         print_status "${COLOR_RED}" "\n\tPlease enter a valid number"
     fi
-    echo -en "\n\tHit any key to continue"
+    echo -en "\n\tPress any key to continue"
     read -k 1
 done
 

--- a/ShellScripts/Brewdocm.sh
+++ b/ShellScripts/Brewdocm.sh
@@ -82,7 +82,7 @@ while true; do
         clear
         echo "Please enter a valid number"
     fi
-    echo -en "\n\n\t\t\tHit any key to continue"
+    echo -en "\n\n\t\t\tPress any key to continue"
     read -k 1 line
 done
 

--- a/ShellScripts/Brewm.sh
+++ b/ShellScripts/Brewm.sh
@@ -32,7 +32,7 @@ function viewbrewfile {
     format_printf "Brew File..." "yellow" "bold"
     printf "\n"
     cat ~/Brewfile
-    printf "\n\n\t\t\tHit any key to view App Descriptions"
+    printf "\n\n\t\t\tPress any key to view App Descriptions"
     read -k 1 line
     # Display Selected Brew File App Descriptions
     clear
@@ -164,7 +164,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        printf "\n\n\t\t\tHit any key to continue"
+        printf "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Crypm.sh
+++ b/ShellScripts/Crypm.sh
@@ -116,7 +116,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Crypvault.sh
+++ b/ShellScripts/Crypvault.sh
@@ -273,6 +273,6 @@ while true; do
 
     # Pause before next iteration
     printf "\n"
-    printf "Hit any key to continue"
+    printf "Press any key to continue"
     read -k 1
 done

--- a/ShellScripts/Devm.sh
+++ b/ShellScripts/Devm.sh
@@ -89,7 +89,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/GauthMgr.sh
+++ b/ShellScripts/GauthMgr.sh
@@ -132,7 +132,7 @@ process_operation() {
             printf "\n\n"
             cat "$DECRYPTED_FILE"
             printf "\n"
-            read -r "?Hit any key to continue"
+            read -r "?Press any key to continue"
             ;;
         *)
             error_printf "Unknown operation: $operation" true

--- a/ShellScripts/Infom.sh
+++ b/ShellScripts/Infom.sh
@@ -132,7 +132,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
     if [ $CLOSE_FINDER_WINDOWS -eq 1 ]; then

--- a/ShellScripts/Ipm.sh
+++ b/ShellScripts/Ipm.sh
@@ -80,7 +80,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Mm.sh
+++ b/ShellScripts/Mm.sh
@@ -94,7 +94,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Netm.sh
+++ b/ShellScripts/Netm.sh
@@ -60,7 +60,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Opsm.sh
+++ b/ShellScripts/Opsm.sh
@@ -84,7 +84,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Sshdir.sh
+++ b/ShellScripts/Sshdir.sh
@@ -11,7 +11,7 @@ for file in $HOME/.ssh/*; do
         echo "$file Contents..." 
 	echo
 	cat $file
-	echo -en "\n\n\t\t\tHit any key to continue"
+	echo -en "\n\n\t\t\tPress any key to continue"
 	read -k 1 line
 	clear
     fi 
@@ -23,7 +23,7 @@ for file in $HOME/zVlt/*; do
         echo "$file Contents..." 
 	echo
 	cat $file
-	echo -en "\n\n\t\t\tHit any key to continue"
+	echo -en "\n\n\t\t\tPress any key to continue"
 	read -k 1 line
 	clear
     fi 

--- a/ShellScripts/Sshm.sh
+++ b/ShellScripts/Sshm.sh
@@ -91,7 +91,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/Tmm.sh
+++ b/ShellScripts/Tmm.sh
@@ -80,7 +80,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/UtilAllDisk.sh
+++ b/ShellScripts/UtilAllDisk.sh
@@ -22,7 +22,7 @@ get_yes_no() {
 # Optional key prompt
 hit_any_key_prompt() {
     if [[ "${hit_any_key:-false}" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 _
     fi
 }

--- a/ShellScripts/UtilAllPack.sh
+++ b/ShellScripts/UtilAllPack.sh
@@ -22,7 +22,7 @@ get_yes_no() {
 # Optional key prompt
 hit_any_key_prompt() {
     if [[ "${hit_any_key:-false}" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 _
     fi
 }

--- a/ShellScripts/Utilm.sh
+++ b/ShellScripts/Utilm.sh
@@ -131,7 +131,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done

--- a/ShellScripts/zTests/Mmt.sh
+++ b/ShellScripts/zTests/Mmt.sh
@@ -45,6 +45,11 @@ function zselectoption {
 	~/bin/zTests/zSelectOption.sh
 }
 
+function zreplacetext {
+	clear
+	bat ~/bin/zTests/zReplaceText.sh
+}
+
 function menu {
 	clear
 	echo
@@ -57,6 +62,7 @@ function menu {
 	echo -e "\t6. zUserinput"
 	echo -e "\t7. zDaysOfMonth"
 	echo -e "\t8. zSelectOption"
+	echo -e "\t9. View zReplaceText"
 	echo -e "\t0. Exit Menu\n\n"
 	echo -en "\t\tEnter an Option: "
         # Read entire input instead of just one character
@@ -105,6 +111,10 @@ while true; do
 		;;
 	    8)
 		zselectoption
+		hit_any_key=true
+		;;
+	    9)
+		zreplacetext
 		hit_any_key=true
 		;;
             *)

--- a/ShellScripts/zTests/zReplaceText.sh
+++ b/ShellScripts/zTests/zReplaceText.sh
@@ -1,0 +1,44 @@
+#!/bin/zsh
+# Change text in scripts from one string to another
+# Exit on any error
+set -e
+
+# Go to target directory
+cd $HOME/Desktop/claude_workspace/scripts
+
+# Find files with the text and log them
+grep -rl 'Hit any key' --include='*.sh' . > changes.log
+
+# Apply the changes
+if [[ -s "changes.log" ]]; then
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        echo "Updating $file"
+        sed -i.bak 's/Hit any key/Press any key/g' "$file"
+    done < changes.log
+else
+    echo "No files found containing 'Hit any key'"
+fi
+
+# Check if changes.log exists
+if [[ ! -f "changes.log" ]]; then
+    echo "Error: changes.log not found in current directory"
+    exit 1
+fi
+
+# Create origfiles directory if it doesn't exist
+# mkdir -p $HOME/bin
+
+# Copy updated files
+while IFS= read -r filename; do
+    [[ -z "$filename" ]] && continue
+    
+    if [[ -f "$filename" ]]; then
+        echo "Copying: $filename"
+        cp "$filename" $HOME/bin
+    else
+        echo "Warning: File not found: $filename"
+    fi
+done < changes.log
+
+echo "Copy operation completed."


### PR DESCRIPTION
Updated all shell scripts to use the more standard prompt 'Press any key to continue' instead of 'Hit any key to continue'. Added zReplaceText.sh utility script for automating this replacement and integrated it into the zTests/Mmt.sh test menu.