### PR TITLE
Update comment to reference $HOME/bin directory

### DIFF
--- a/ShellScripts/zTests/zReplaceText.sh
+++ b/ShellScripts/zTests/zReplaceText.sh
@@ -26,7 +26,7 @@ if [[ ! -f "changes.log" ]]; then
     exit 1
 fi
 
-# Create origfiles directory if it doesn't exist
+# Create $HOME/bin directory if it doesn't exist
 # mkdir -p $HOME/bin
 
 # Copy updated files


### PR DESCRIPTION
Changed a comment to correctly refer to the $HOME/bin directory instead of origfiles, improving clarity in the script.