### PR TITLE
Update prompt text to 'Press any key to continue'

### DIFF
--- a/ShellScripts/zTests/Mmt.sh
+++ b/ShellScripts/zTests/Mmt.sh
@@ -133,7 +133,7 @@ while true; do
     fi
     # Check if the user should be prompted to hit any key to continue
     if [[ "$hit_any_key" == "true" ]]; then
-        echo -en "\n\n\t\t\tHit any key to continue"
+        echo -en "\n\n\t\t\tPress any key to continue"
         read -k 1 line
     fi
 done


### PR DESCRIPTION
Changed the user prompt from 'Hit any key to continue' to 'Press any key to continue' for improved clarity and consistency.