### PR TITLE
Update app name from macvim to macvim-app in Brewapps.sh

### DIFF
--- a/ShellScripts/Brewapps.sh
+++ b/ShellScripts/Brewapps.sh
@@ -11,7 +11,7 @@ format_printf "App Descriptions..." "yellow" "bold"
 printf "\n"
 
 # Array of app names
-apps=("pyenv:" "iperf3:" "jq:" "qlmarkdown:" "macdown:" "speedtest:" "github:" "macvim:" "syntax-highlight:")
+apps=("pyenv:" "iperf3:" "jq:" "qlmarkdown:" "macdown:" "speedtest:" "github:" "macvim-app:" "syntax-highlight:")
 
 # Function to check if a line contains an app name
 contains_app() {


### PR DESCRIPTION
Replaces 'macvim:' with 'macvim-app:' in the apps array to reflect the correct Homebrew cask name.