### PR TITLE
Update README wording for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Note:** This repository contains sample code for educational and personal use. Pull requests from outside contributors are not accepted. Security reports are always welcome!
 
-This repository includes MacOS code snippets and other examples that can be helpful for learning, experimentation, and personal projects. These are intended solely as educational code samples.  
+This repository contains MacOS code snippets and other examples that can be helpful for learning, experimentation, and personal projects. These are intended solely as educational code samples.  
 
 If you choose to use any of this code, be sure to test thoroughly in your own environment. **Use at your own risk.**
 


### PR DESCRIPTION
Revised the README to improve clarity by changing 'includes' to 'contains' in the description of the repository contents.