### PR TITLE
Remove unused LOGS_DIR variable from PyUninstall.sh

### DIFF
--- a/ShellScripts/PyUninstall.sh
+++ b/ShellScripts/PyUninstall.sh
@@ -1,8 +1,6 @@
 #!/bin/zsh
 # Source function library with error handling
 FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
-LOGS_DIR="$HOME/.logs"
-
 [[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 


### PR DESCRIPTION
Deleted the LOGS_DIR variable assignment as it was not used in the script, simplifying the code.