### PR TITLE
Rename 'fo' alias to 'of' for opening Finder

### DIFF
--- a/DotFiles/.zshrc
+++ b/DotFiles/.zshrc
@@ -128,7 +128,7 @@ alias pipup="PipUpdate.sh"			# Update Python Packages
 alias vimup="VimUpdate.sh"			# Update Vim Plugins
 alias fedoc="FLibFormatEchoDoc.sh"		# List FLibFormatEcho.sh Documentation
 alias fpdoc="FLibFormatPrintfDoc.sh"		# List FLibFormatPrintf.sh Documentation
-alias fo="open ."				# Open Current Directory in Finder
+alias of="open ."				# Open Current Directory in Finder
 alias np="clear; echo 'Node Processes...'; echo; echo 'PID    CPU  MEM  COMMAND'; ps aux | grep node | grep -v grep | awk '{print \$2, \$3, \$4, \$11}' | column -t" # List Node Processes with Header
 alias ctest="Colortest.sh"			# Display Color Test
 alias webapps="clear; echo 'Web Apps...'; echo; ls --color=never -1 ~/Applications; echo" # List Safari Web Apps


### PR DESCRIPTION
Changed the alias from 'fo' to 'of' for opening the current directory in Finder to avoid potential conflicts or for improved mnemonic consistency.