### PR TITLE
Fix indentation for hit_any_key assignment

### DIFF
--- a/ShellScripts/Brewdocm.sh
+++ b/ShellScripts/Brewdocm.sh
@@ -66,11 +66,11 @@ while true; do
                 ;;
             1)
                 brewdocs1
-		hit_any_key=true
+                hit_any_key=true
                 ;;
             2)
                 brewdocs2
-		hit_any_key=true
+                hit_any_key=true
                 ;;
             3)
                 brewdocs3

--- a/ShellScripts/Brewdocm.sh
+++ b/ShellScripts/Brewdocm.sh
@@ -74,7 +74,7 @@ while true; do
                 ;;
             3)
                 brewdocs3
-		hit_any_key=true
+                hit_any_key=true
                 ;;
             *)
                 clear


### PR DESCRIPTION
Corrected indentation for the hit_any_key variable assignment in the case statements to improve code readability and maintain consistency.