### PR TITLE
Improve 'press any key' prompt formatting

### DIFF
--- a/ShellScripts/Brewautom2.sh
+++ b/ShellScripts/Brewautom2.sh
@@ -266,8 +266,12 @@ while true; do
         clear
         print_status "${COLOR_RED}" "\n\tPlease enter a valid number"
     fi
-    echo -en "\n\tPress any key to continue"
-    read -k 1
+    printf "\n\n\t\t\t"
+    # Use printf with info formatting but without newline
+    printf '\033[1;34m%s\033[0m' "ℹ️  Press any key to continue"
+    read -k 1 line
+#    echo -en "\n\tPress any key to continue"
+#    read -k 1
 done
 
 # Reset Ctrl-C behavior to default


### PR DESCRIPTION
Updated the prompt to use colored info formatting and improved alignment for better user experience. The message now uses printf with blue color and an info icon.