### PR TITLE
Update exit message in TOTP viewer script

### DIFF
--- a/ShellScripts/ZshOtpGenerator.sh
+++ b/ShellScripts/ZshOtpGenerator.sh
@@ -133,7 +133,7 @@ cleanup_and_exit() {
     [[ -f "$DECRYPTED_FILE" ]] && { rm -P "$DECRYPTED_FILE" 2>/dev/null || rm "$DECRYPTED_FILE"; }
     unset GAUTH_PASSWORD
     echo ""
-    info_printf "Exiting TOTP viewer. Goodbye!"
+    info_printf "Exiting TOTP viewer!"
     exit 0
 }
 


### PR DESCRIPTION
Removes the word 'Goodbye!' from the exit message in the ZshOtpGenerator.sh script for a more concise output.