### PR TITLE
Add commented option for custom Java DMG download dir

### DIFF
--- a/ShellScripts/JavaUpdate.sh
+++ b/ShellScripts/JavaUpdate.sh
@@ -68,6 +68,8 @@ find_architecture_dmg() {
 # Enhanced download function with progress and error handling
 download_java_dmg() {
     local dmg_url="$1"
+    # Uncomment and modify the line below to use a specific subdirectory
+    # local download_dir="$HOME/Downloads/Java/Azul/ARM Java Installation"
     local download_dir="$HOME/Downloads"
     local download_path="$download_dir/$(basename "$dmg_url")"
     


### PR DESCRIPTION
Added a commented line in download_java_dmg to allow easy modification of the download directory to a specific subdirectory for Java/Azul/ARM installations. This provides flexibility for users who want to organize downloaded DMG files.