### PR TITLE
Bump date-generator to v4.0.21

### DIFF
--- a/mcp-servers/date-generator/manifest.json
+++ b/mcp-servers/date-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "date-generator-mcp",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "MCP server for generating dates by month, year, and day of week",
   "author": {
     "name": "Bruce Guthrie"

--- a/mcp-servers/date-generator/package-lock.json
+++ b/mcp-servers/date-generator/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "date-generator-mcp",
-      "version": "4.0.20",
+      "version": "4.0.21",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.2",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
       }
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mcp-servers/date-generator/package.json
+++ b/mcp-servers/date-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "MCP server for generating dates by month, year, and day of week",
   "main": "src/index.ts",
   "type": "module",
@@ -14,7 +14,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.5.2",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   },


### PR DESCRIPTION
Release bump for date-generator-mcp to 4.0.21 and update dev dependency @types/node to ^25.5.2. Includes updated package and manifest metadata and a refreshed compiled mcpb binary.