### PR TITLE
Underline menu headers in shell scripts

### DIFF
--- a/ShellScripts/Brewm.sh
+++ b/ShellScripts/Brewm.sh
@@ -146,7 +146,7 @@ function brewappmaint {
 function menu {
     clear
     printf "\n"
-    printf "\t\t\t\033[33;1mHomeBrew Menu\033[0m\n\n"
+    printf "\t\t\t\033[33;1;4mHomeBrew Menu\033[0m\n\n"
     printf "\t1. Brewit\n"
     printf "\t2. Brew List\n"
     printf "\t3. Brew Dependencies\n"

--- a/ShellScripts/Crypm.sh
+++ b/ShellScripts/Crypm.sh
@@ -43,7 +43,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Crypt Menu" "yellow" "bold"
+    format_printf "Crypt Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Enigma Shortcut\n"
     printf "\t2. SSL Cryptxt\n"

--- a/ShellScripts/Devm.sh
+++ b/ShellScripts/Devm.sh
@@ -52,7 +52,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Dev Menu" "yellow" "bold"
+    format_printf "Dev Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Devsync (Dev to Local Repo)\n"
     printf "\t2. GitHub Desktop (Local Repo to GitHub)\n"

--- a/ShellScripts/Infom.sh
+++ b/ShellScripts/Infom.sh
@@ -74,7 +74,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Info Menu" "yellow" "bold"
+    format_printf "Info Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Hostname\n"
     printf "\t2. Environment Variables\n"

--- a/ShellScripts/Ipm.sh
+++ b/ShellScripts/Ipm.sh
@@ -32,7 +32,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "iPerf3 Menu" "yellow" "bold"
+    format_printf "iPerf3 Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Start iPerf Server\n"
     printf "\t2. Client to Server Speedtest\n"

--- a/ShellScripts/Mm.sh
+++ b/ShellScripts/Mm.sh
@@ -41,7 +41,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Main Menu" "yellow" "bold"
+    format_printf "Main Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Homebrew Menu\n"
     printf "\t2. Ops Menu\n"

--- a/ShellScripts/Netm.sh
+++ b/ShellScripts/Netm.sh
@@ -22,7 +22,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Network Menu" "yellow" "bold"
+    format_printf "Network Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Internet Speed Test\n"
     printf "\t2. Apple Network Quality Test\n"

--- a/ShellScripts/Opsm.sh
+++ b/ShellScripts/Opsm.sh
@@ -36,7 +36,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Ops Menu" "yellow" "bold"
+    format_printf "Ops Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Info Menu\n"
     printf "\t2. Network Menu\n"

--- a/ShellScripts/Sshm.sh
+++ b/ShellScripts/Sshm.sh
@@ -39,7 +39,7 @@ function menu {
 	clear
 	printf "\n"
 	printf "\t\t\t"
-	format_printf "SSH Menu" "yellow" "bold"
+	format_printf "SSH Menu" "yellow" "bold" "underline"
 	printf "\n"
 	printf "\t1. Set SSH Password\n"
 	printf "\t2. Turn SSH On\n"

--- a/ShellScripts/Tmm.sh
+++ b/ShellScripts/Tmm.sh
@@ -31,7 +31,7 @@ function menu {
 	clear
 	printf "\n"
 	printf "\t\t\t"
-	format_printf "Time Machine Menu" "yellow" "bold"
+	format_printf "Time Machine Menu" "yellow" "bold" "underline"
 	printf "\n"
 	printf "\t1. Set Time Machine Password\n"
 	printf "\t2. Run Time Machine Backup\n"

--- a/ShellScripts/Utilm.sh
+++ b/ShellScripts/Utilm.sh
@@ -46,7 +46,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Utility Menu" "yellow" "bold"
+    format_printf "Utility Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. Vim Plugin Update\n"
     printf "\t2. Java Update\n"

--- a/ShellScripts/zTests/Mmt.sh
+++ b/ShellScripts/zTests/Mmt.sh
@@ -53,7 +53,7 @@ function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Test Menu" "yellow" "bold"
+    format_printf "Test Menu" "yellow" "bold" "underline"
     printf "\n"
     printf "\t1. zDialogBox\n"
     printf "\t2. zJQJsonConfig\n"


### PR DESCRIPTION
Add underline styling to menu headers for consistency and improved visibility. Brewm.sh's ANSI header was updated to include the underline code, and other menus now pass the "underline" flag to format_printf. Affected files: ShellScripts/Brewm.sh, Crypm.sh, Devm.sh, Infom.sh, Ipm.sh, Mm.sh, Netm.sh, Opsm.sh, Sshm.sh, Tmm.sh, Utilm.sh, and ShellScripts/zTests/Mmt.sh.