### PR TITLE
Bump date-generator to v4.0.22

### DIFF
--- a/mcp-servers/date-generator/manifest.json
+++ b/mcp-servers/date-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "date-generator-mcp",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "MCP server for generating dates by month, year, and day of week",
   "author": {
     "name": "Bruce Guthrie"

--- a/mcp-servers/date-generator/package-lock.json
+++ b/mcp-servers/date-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "date-generator-mcp",
-      "version": "4.0.21",
+      "version": "4.0.22",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1092,9 +1092,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-servers/date-generator/package.json
+++ b/mcp-servers/date-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "MCP server for generating dates by month, year, and day of week",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Release: bump package version to 4.0.22 in manifest.json and package.json, include rebuilt binary artifact (date-generator.mcpb), and update package-lock. This is a patch release to publish the latest changes and regenerated build artifacts.