### PR TITLE
Bump date-generator to v4.0.23

### DIFF
--- a/mcp-servers/date-generator/manifest.json
+++ b/mcp-servers/date-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "date-generator-mcp",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "description": "MCP server for generating dates by month, year, and day of week",
   "author": {
     "name": "Bruce Guthrie"

--- a/mcp-servers/date-generator/package-lock.json
+++ b/mcp-servers/date-generator/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "date-generator-mcp",
-      "version": "4.0.22",
+      "version": "4.0.23",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "devDependencies": {
-        "@types/node": "^25.5.2",
+        "@types/node": "^25.6.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
       }
@@ -512,13 +512,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/accepts": {
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/mcp-servers/date-generator/package.json
+++ b/mcp-servers/date-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "description": "MCP server for generating dates by month, year, and day of week",
   "main": "src/index.ts",
   "type": "module",
@@ -14,7 +14,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
+    "@types/node": "^25.6.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   },


### PR DESCRIPTION
Release: bump package version to 4.0.23 in manifest.json and package.json and regenerate package-lock.json. Update dev dependency @types/node to ^25.6.0 (reflected in lockfile) and update undici-types to 7.19.2. Include updated built binary date-generator.mcpb.