### PR TITLE
Add oc alias for opencode AI agent

### DIFF
--- a/DotFiles/.zshrc
+++ b/DotFiles/.zshrc
@@ -125,6 +125,7 @@ bak() { for f; do cp -- "$f"{,.bak}; done }     # Function to make backup copies
 alias vimup="VimUpdate.sh"			# Update Vim Plugins
 alias fedoc="FLibFormatEchoDoc.sh"		# List FLibFormatEcho.sh Documentation
 alias fpdoc="FLibFormatPrintfDoc.sh"		# List FLibFormatPrintf.sh Documentation
+alias oc="opencode"				# Launch Opencode AI Coding Agent
 alias of="open ."				# Open Current Directory in Finder
 alias np="clear; echo 'Node Processes...'; echo; echo 'PID    CPU  MEM  COMMAND'; ps aux | grep node | grep -v grep | awk '{print \$2, \$3, \$4, \$11}' | column -t" # List Node Processes with Header
 alias npml="clear; echo 'Global NPM Packages...'; echo; npm list -g --depth=0"	# List Global NPM Packages


### PR DESCRIPTION
Add an alias oc='opencode' to DotFiles/.zshrc to provide a short command for launching the Opencode AI Coding Agent. The new alias is added alongside existing shell shortcuts and does not affect other configurations.