### PR TITLE
Add Shortcuts Hash Files backup support

### DIFF
--- a/ShellScripts/BackupSummary.sh
+++ b/ShellScripts/BackupSummary.sh
@@ -68,6 +68,8 @@ function main {
     local private_path="/Volumes/Private"
     local shortcuts_downloads="$downloads_path/Shortcuts Config Files"
     local shortcuts_private="$private_path/Shortcuts Config Files"
+    local shortcuts_hash_downloads="$downloads_path/Shortcuts Hash Files"
+    local shortcuts_hash_private="$private_path/Shortcuts Hash Files"
     local brukasa_disk=false
     
     # Determine if BruKasa Thumb Drive is connected
@@ -89,12 +91,22 @@ function main {
     fi
     
     # Search for JSON files
+    # Shortcuts Config Files
     print_header "JSON Files in ~/Downloads/zVault Backup/Shortcuts Config Files"
     search_files "$shortcuts_downloads" "*.json"
     
     if [[ "$brukasa_disk" == "true" ]]; then
         print_header "JSON Files in /Volumes/Private/Shortcuts Config Files"
         search_files "$shortcuts_private" "*.json"
+    fi	
+
+    # Shortcuts Hash Files
+    print_header "JSON Files in ~/Downloads/zVault Backup/Shortcuts Hash Files"
+    search_files "$shortcuts_hash_downloads" "*.json"
+    
+    if [[ "$brukasa_disk" == "true" ]]; then
+        print_header "JSON Files in /Volumes/Private/Shortcuts Hash Files"
+        search_files "$shortcuts_hash_private" "*.json"
     fi	
 
     # Ask to Eject Brukasa Thumb Drive

--- a/ShellScripts/Crypvault.sh
+++ b/ShellScripts/Crypvault.sh
@@ -228,6 +228,10 @@ while true; do
         config_file="$config_dir/gitmgr_config.json"
     fi
     
+    # Set Hash Configuration Files Location
+    hash_dir="$HOME/Library/Mobile Documents/iCloud~is~workflow~my~workflows/Documents/Hash Files"
+    hash_files="$hash_dir/*.*"
+
     # Determine Type of Encryption Used on Vault
     if grep -q -w SSL "$config_file"; then 
         encrypt_type="SSL"   
@@ -328,10 +332,12 @@ while true; do
                 info_printf "Backing up to Private..."
                 cp "$icloud_enc" "/Volumes/Private"
                 cp "$config_file" "/Volumes/Private/Shortcuts Config Files"
+                cp "$hash_files" "/Volumes/Private/Shortcuts Hash Files"
             fi
             info_printf "Backing up to Downloads..."
             cp "$icloud_enc" "$HOME/Downloads/zVault Backup"
             cp "$config_file" "$HOME/Downloads/zVault Backup/Shortcuts Config Files"
+            cp "$hash_files" "$HOME/Downloads/zVault Backup/Shortcuts Hash Files"
             info_printf "Vault Backup Completed"
             ;;
     esac


### PR DESCRIPTION
Include Shortcuts Hash Files in backup and summary routines.

- BackupSummary.sh: add variables for Downloads and /Volumes/Private hash file folders, and include headers and searches for JSON hash files (prints and searches both Downloads and Private when the Brukasa drive is present).
- Crypvault.sh: set hash_dir to the iCloud Shortcuts Hash Files path and add copy operations so hash files are backed up to both /Volumes/Private/Shortcuts Hash Files and ~/Downloads/zVault Backup/Shortcuts Hash Files.

This ensures hash files stored in iCloud are discovered and included alongside Shortcuts Config Files during backups.