### PR TITLE
Update date-generator version to 4.0.1

### DIFF
--- a/mcp-servers/date-generator/manifest.json
+++ b/mcp-servers/date-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "date-generator-mcp",
-  "version": "4.0.25",
+  "version": "4.0.1",
   "description": "MCP server for generating dates by month, year, and day of week",
   "author": {
     "name": "Bruce Guthrie"

--- a/mcp-servers/date-generator/package-lock.json
+++ b/mcp-servers/date-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.25",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "date-generator-mcp",
-      "version": "4.0.25",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/mcp-servers/date-generator/package.json
+++ b/mcp-servers/date-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-generator-mcp",
-  "version": "4.0.25",
+  "version": "4.0.1",
   "description": "MCP server for generating dates by month, year, and day of week",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Align package metadata and binary for the date-generator MCP server by changing the published version from 4.0.25 to 4.0.1. Updated manifest.json, package.json, package-lock.json and the date-generator.mcpb binary to reflect the corrected version and ensure consistency across the package artifacts.