### PR TITLE
Add DeleteFork script; update Devm menu; fix fork

### DIFF
--- a/ShellScripts/AutoForkClone.sh
+++ b/ShellScripts/AutoForkClone.sh
@@ -200,7 +200,7 @@ if [[ "$SKIP_FORK" != true ]]; then
   if gh repo view "$GITHUB_USER/$REPO_NAME" &>/dev/null; then
     success_printf "Fork already exists in your account"
   else
-    if ! gh repo fork "$REPO_URL" --clone=false --remote=false; then
+    if ! gh repo fork "$REPO_URL" --clone=false; then
       error_printf "Fork failed. Check repository access and permissions." true
     fi
     time_printf "Waiting for fork to be ready..."

--- a/ShellScripts/DeleteFork.sh
+++ b/ShellScripts/DeleteFork.sh
@@ -1,0 +1,51 @@
+#!/bin/zsh
+
+# Delete a GitHub fork and its local clone
+# Usage: ./delete-fork.sh (prompts for repository name to delete)
+
+# Source function library with error handling
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
+source "$FORMAT_LIBRARY"
+
+# Heading
+clear
+format_printf "Delete Fork..." "yellow" "bold"
+printf "\n"
+
+# Prompt for repository name
+info_printf "Please enter the name of the GitHub fork to delete."
+read "REPO_NAME?Repo name: "
+if [ -z "$REPO_NAME" ]; then
+  error_printf "Repository name cannot be empty."
+  exit 1
+fi
+
+LOCAL_DIR="$HOME/Documents/GitHub/$REPO_NAME"
+
+# Get the current GitHub username (requires gh CLI)
+GITHUB_USER=$(gh api user --jq .login)
+
+# Confirm deletion
+warning_printf "This will delete:"
+format_printf "  - Remote repo: https://github.com/$GITHUB_USER/$REPO_NAME" none
+format_printf "  - Local folder: $LOCAL_DIR" none
+read -q "REPLY?Proceed? (y/n) "
+echo
+[[ $REPLY != [yY] ]] && { error_printf "Cancelled."; exit 0 }
+
+# Delete remote repo
+clean_printf "Deleting remote fork from GitHub..."
+if gh repo delete "$GITHUB_USER/$REPO_NAME" --yes; then
+  # Delete local directory only if remote deletion succeeded
+  if [ -d "$LOCAL_DIR" ]; then
+    clean_printf "Removing local clone..."
+    rm -rf "$LOCAL_DIR"
+  else
+    warning_printf "Local directory not found: $LOCAL_DIR"
+  fi
+  success_printf "Done! The fork '$REPO_NAME' has been removed."
+else
+  error_printf "Failed to delete remote repository. Local directory was not removed."
+  exit 1
+fi

--- a/ShellScripts/Devm.sh
+++ b/ShellScripts/Devm.sh
@@ -38,6 +38,11 @@ function autofork {
     AutoForkClone.sh
 }
 
+function deletefork {
+    clear
+    DeleteFork.sh
+}
+
 function mbat {
     clear
     MBat.sh
@@ -68,9 +73,10 @@ function menu {
     printf "\t\033[4;36mCoding and Utilities\033[0m\n"
     printf "\t5. Replace Shellscript Text\n"
     printf "\t6. Auto Fork and Clone Repo\n"
-    printf "\t7. Bat Menu Viewer\n"
-    printf "\t8. Hash Key Report\n"
-    printf "\t9. Crypt Menu\n"
+    printf "\t7. Delete Fork\n"
+    printf "\t8. Bat Menu Viewer\n"
+    printf "\t9. Hash Key Report\n"
+    printf "\t10. Crypt Menu\n"
     printf "\n"
     printf "\t0. Exit Menu\n\n"
     printf "\t\tEnter an Option: "
@@ -125,14 +131,18 @@ while true; do
                 hit_any_key=true
                 ;;
             7)
-                mbat
+                deletefork
                 hit_any_key=true
                 ;;
             8)
-                hlist
+                mbat
                 hit_any_key=true
                 ;;
             9)
+                hlist
+                hit_any_key=true
+                ;;
+            10)
                 crypmenu
                 ;;
             *)


### PR DESCRIPTION
Remove the erroneous --remote=false option from gh repo fork in AutoForkClone.sh to allow the fork command to complete as intended. Add a new ShellScripts/DeleteFork.sh script that prompts for a repo, confirms deletion, removes the remote fork via gh and then deletes the local clone (uses FLibFormatPrintf.sh for formatting). Update Devm.sh to add a deletefork wrapper, adjust menu labels/numbers, and remap menu handlers so the new Delete Fork option is available.