### PR TITLE
Add NPM menu and improve NPM helper scripts

### DIFF
--- a/DotFiles/.zshrc
+++ b/DotFiles/.zshrc
@@ -128,8 +128,8 @@ alias fpdoc="FLibFormatPrintfDoc.sh"		# List FLibFormatPrintf.sh Documentation
 alias oc="opencode"				# Launch Opencode AI Coding Agent
 alias of="open ."				# Open Current Directory in Finder
 alias np="clear; echo 'Node Processes...'; echo; echo 'PID    CPU  MEM  COMMAND'; ps aux | grep node | grep -v grep | awk '{print \$2, \$3, \$4, \$11}' | column -t" # List Node Processes with Header
-alias npml="clear; printf '\033[1;33mGlobal NPM Packages...\033[0m\n'; printf '\n'; npm list -g --depth=0"
-alias npmo="clear; printf '\033[1;33mOutdated NPM Packages...\033[0m\n'; printf '\n'; npm outdated -g --depth=0"
+alias npml="NpmList.sh"			        # List Global NPM Packages
+alias npmo="NpmOutdated.sh"			# List Outdated Global NPM Packages
 alias npmu="NpmGlobalUninstall.sh"              # Uninstall Global NPM Packages
 alias npmgu="NpmGlobalUpdates.sh"               # Update Global NPM Packages
 alias ds="clear; echo 'Disk Space...'; echo; diskspace --human-readable" # List Disk Space

--- a/ShellScripts/NpmGlobalUninstall.sh
+++ b/ShellScripts/NpmGlobalUninstall.sh
@@ -7,19 +7,38 @@ FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
 source "$FORMAT_LIBRARY"
 
 clear
-rocket_printf "Starting npm global package cleanup..."
+rocket_printf "Starting NPM global package uninstall..."
 printf '\n'
 
-if [[ -z "$1" ]]; then
-  error_printf "Usage: $0 <package-name>" true
+# Check that npm is available on the system
+if ! command -v npm &>/dev/null; then
+  error_printf "npm is not installed or not in PATH. Please install Node.js/npm first." true
+  exit 1
 fi
 
-PACKAGE="$1"
+# Prompt user for package name with validation
+while true; do
+  read "PACKAGE?Enter the name of the global npm package to uninstall: "
+  if [[ -z "$PACKAGE" ]]; then
+    error_printf "Package name cannot be empty. Please try again."
+  else
+    break
+  fi
+done
+
 info_printf "Checking for global npm package: $PACKAGE"
 
 # Get npm global directories
-NPM_GLOBAL_DIR=$(npm root -g)
-NPM_BIN_DIR=$(npm bin -g)
+NPM_GLOBAL_DIR=$(npm root -g 2>/dev/null) || { error_printf "Failed to get npm global directory" true; exit 1; }
+NPM_BIN_DIR="$(npm config get prefix 2>/dev/null)/bin"
+if [[ ! -d "$NPM_BIN_DIR" ]]; then
+  error_printf "Failed to determine npm bin directory" true
+  exit 1
+fi
+
+# Check if sudo is available for privilege escalation
+SUDO_AVAILABLE=false
+command -v sudo &>/dev/null && SUDO_AVAILABLE=true
 
 # Step 1: Check if package is actually installed
 if [[ ! -d "$NPM_GLOBAL_DIR/$PACKAGE" ]]; then
@@ -28,11 +47,10 @@ if [[ ! -d "$NPM_GLOBAL_DIR/$PACKAGE" ]]; then
 else
   package_printf "Found $PACKAGE at: $NPM_GLOBAL_DIR/$PACKAGE"
   INSTALLED=true
-  
+
   # Get list of binaries this package provides before uninstalling
   BINARIES=()
   if [[ -f "$NPM_GLOBAL_DIR/$PACKAGE/package.json" ]]; then
-    # Extract bin entries from package.json
     BINARIES=($(node -pe "
       try {
         const pkg = require('$NPM_GLOBAL_DIR/$PACKAGE/package.json');
@@ -46,15 +64,26 @@ else
   fi
 fi
 
-# Step 2: Uninstall globally
+# Step 2: Confirm and uninstall globally
 if [[ "$INSTALLED" == true ]]; then
+  format_printf "Ready to uninstall $PACKAGE" "blue" "bold" "🧩"
+  read -k "CONFIRM?Proceed with uninstall? (y/N): "
+  printf '\n'
+  if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+    info_printf "Uninstall cancelled."
+    exit 0
+  fi
+
   format_printf "Uninstalling $PACKAGE..." "blue" "bold" "🧩"
   npm uninstall -g "$PACKAGE" 2>/dev/null
-  
-  # Check if uninstall failed due to permissions
+
   if [[ $? -ne 0 ]]; then
-    warning_printf "Permission denied, trying with sudo..."
-    sudo npm uninstall -g "$PACKAGE"
+    if [[ "$SUDO_AVAILABLE" == true ]]; then
+      warning_printf "Permission denied, trying with sudo..."
+      sudo npm uninstall -g "$PACKAGE"
+    else
+      warning_printf "Permission denied and sudo is not available. Try running as root."
+    fi
   fi
 fi
 
@@ -65,7 +94,10 @@ if [[ ${#BINARIES[@]} -gt 0 ]]; then
     BIN_PATH="$NPM_BIN_DIR/$BIN"
     if [[ -L "$BIN_PATH" ]] || [[ -f "$BIN_PATH" ]]; then
       format_printf "Removing: $BIN_PATH" "cyan" "italic" "⚙️ "
-      sudo rm -f "$BIN_PATH"
+      rm -f "$BIN_PATH" 2>/dev/null
+      if [[ $? -ne 0 && "$SUDO_AVAILABLE" == true ]]; then
+        sudo rm -f "$BIN_PATH"
+      fi
     fi
   done
 else
@@ -73,21 +105,23 @@ else
   BIN_PATH="$NPM_BIN_DIR/$PACKAGE"
   if [[ -L "$BIN_PATH" ]] || [[ -f "$BIN_PATH" ]]; then
     clean_printf "Removing binary: $BIN_PATH"
-    sudo rm -f "$BIN_PATH"
+    rm -f "$BIN_PATH" 2>/dev/null
+    if [[ $? -ne 0 && "$SUDO_AVAILABLE" == true ]]; then
+      sudo rm -f "$BIN_PATH"
+    fi
   fi
 fi
 
 # Step 4: Clean up package directory if it still exists
 if [[ -d "$NPM_GLOBAL_DIR/$PACKAGE" ]]; then
   format_printf "Removing leftover package directory..." "green" "italic" "🗑️ "
-  sudo rm -rf "$NPM_GLOBAL_DIR/$PACKAGE"
+  rm -rf "$NPM_GLOBAL_DIR/$PACKAGE" 2>/dev/null
+  if [[ $? -ne 0 && "$SUDO_AVAILABLE" == true ]]; then
+    sudo rm -rf "$NPM_GLOBAL_DIR/$PACKAGE"
+  fi
 fi
 
-# Step 5: Clear npm cache
-format_printf "Cleaning npm cache..." "green" "italic" "🧺"
-npm cache clean --force >/dev/null 2>&1
-
-# Step 6: Verify removal
+# Step 5: Verify removal
 format_printf "Verifying cleanup..." "blue" "bold" "🔎"
 ISSUES=()
 

--- a/ShellScripts/NpmGlobalUpdates.sh
+++ b/ShellScripts/NpmGlobalUpdates.sh
@@ -8,7 +8,7 @@ FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
 source "$FORMAT_LIBRARY"
 
 clear
-rocket_printf "Starting npm global package updates..."
+rocket_printf "Starting NPM global package updates..."
 printf "\n"
 
 info_printf "Checking outdated global npm packages (excluding npm)..."

--- a/ShellScripts/NpmList.sh
+++ b/ShellScripts/NpmList.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+# List global npm packages
+
+# Source function library with error handling
+
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
+source "$FORMAT_LIBRARY"
+
+clear
+format_printf "Global NPM Packages List..." "yellow" "bold"
+printf "\n"
+
+# Global npm packages (excluding npm itself)
+npm list -g --depth=0
+

--- a/ShellScripts/NpmOutdated.sh
+++ b/ShellScripts/NpmOutdated.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+# Outdated npm packages
+
+# Source function library with error handling
+
+FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
+[[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
+source "$FORMAT_LIBRARY"
+
+clear
+format_printf "Outdated NPM Packages..." "yellow" "bold"
+printf "\n"
+
+# Check for outdated global npm packages
+npm outdated -g --depth=0
+

--- a/ShellScripts/Npmm.sh
+++ b/ShellScripts/Npmm.sh
@@ -7,77 +7,36 @@ FORMAT_LIBRARY="$HOME/ShellScripts/FLibFormatPrintf.sh"
 [[ -f "$FORMAT_LIBRARY" ]] || { printf "Error: Required library $FORMAT_LIBRARY not found" >&2; exit 1; }
 source "$FORMAT_LIBRARY"
 
-function devsync {
+function npmlist {
     clear
-    Devsync.sh
+    NpmList.sh
 }
 
-function ghdesktop { 
+function npmoutdated {
     clear
-    open -a "GitHub Desktop.app"
-    echo "Running GitHub Desktop App..."
+    NpmOutdated.sh
 }
 
-function crypvault {
+function npmglobalupdate {
     clear
-    Crypvault.sh 
+    NpmGlobalUpdates.sh
 }
 
-function bsum {
+function npmglobaluninstall {
     clear
-    BackupSummary.sh
-}
-
-function reptext {
-    clear
-    ReplaceShellText.sh
-}
-
-function mbat {
-    clear
-    MBat.sh
-}
-
-function hlist {
-    clear
-    HashList.sh
-}
-
-function crypmenu {
-    clear
-    Crypm.sh
-}
-
-function gitmenu {
-    clear
-    Gitm.sh
-}
-
-function npmmenu {
-    clear
-    Npmm.sh
+    NpmGlobalUninstall.sh
 }
 
 function menu {
     clear
     printf "\n"
     printf "\t\t\t"
-    format_printf "Dev Menu" "yellow" "bold" "underline"
+    format_printf "NPM Menu" "yellow" "bold" "underline"
     printf "\n"
-    printf "\t\033[4;36mVault Management\033[0m\n"
-    printf "\t1. Devsync (Dev to Local Repo)\n"
-    printf "\t2. GitHub Desktop (Local Repo to GitHub)\n"
-    printf "\t3. Crypvault (Local Repo to iCloud)\n"
-    printf "\t4. Backup Summary\n"
-    printf "\n"
-    printf "\t\033[4;36mCoding and Utilities\033[0m\n"
-    printf "\t5. Replace Shellscript Text\n"
-    printf "\t6. Bat Menu Viewer\n"
-    printf "\t7. Hash Key Report\n"
-    printf "\t8. Crypt Menu\n"
-    printf "\t9. Git Menu\n"
-    printf "\t10. NPM Menu\n"
-    printf "\n"
+    printf "\t1. Global NPM Packages List\n"
+    printf "\t2. Outdated Global NPM Packages\n"
+    printf "\t3. NPM Global Package Updates\n"
+    printf "\t4. Uninstall NPM Global Package\n"
     printf "\t0. Exit Menu\n\n"
     printf "\t\tEnter an Option: "
     # Read Single-key input 
@@ -107,41 +66,20 @@ while true; do
                 break 
                 ;;
             1)
-                devsync
+                npmlist
                 hit_any_key=true
                 ;;
             2)
-                ghdesktop
+                npmoutdated
                 hit_any_key=true
                 ;;
             3)
-                crypvault
+                npmglobalupdate
                 hit_any_key=true
                 ;;
             4)
-                bsum
+                npmglobaluninstall
                 hit_any_key=true
-                ;;
-            5)
-                reptext
-                hit_any_key=true
-                ;;
-            6)
-                mbat
-                hit_any_key=true
-                ;;
-            7)
-                hlist
-                hit_any_key=true
-                ;;
-            8)
-                crypmenu
-                ;;
-            9)
-                gitmenu
-                ;;
-            10)
-                npmmenu
                 ;;
             *)
                 clear
@@ -163,7 +101,7 @@ while true; do
         # Use printf with info formatting but without newline
         printf '\033[1;34m%s\033[0m' "ℹ️  Press any key to continue"
         read -k 1 line
-   fi
+    fi
 done
 
 clear


### PR DESCRIPTION
Replace inline npm aliases with wrapper scripts and add a dedicated NPM menu.

Changes:
- DotFiles/.zshrc: point npml/npmo aliases to NpmList.sh/NpmOutdated.sh and keep other npm aliases.
- ShellScripts/Npmm.sh: new interactive NPM menu providing list, outdated, update, and uninstall actions.
- ShellScripts/NpmList.sh & NpmOutdated.sh: new thin wrappers that source the format library and run npm list/outdated.
- ShellScripts/Devm.sh: add npmmenu function, integrate NPM Menu as option 10, and minor prompt formatting fix.
- ShellScripts/NpmGlobalUninstall.sh: major improvements — check for npm, prompt/validate package name, confirm uninstall, determine npm bin dir robustly, extract package binaries, use sudo fallback when needed, remove files safely, and improved error handling; also update log text to use "NPM".
- ShellScripts/NpmGlobalUpdates.sh: minor log text update to "NPM".

Overall: adds a user-friendly NPM menu and more robust global uninstall/update tooling with better validation and permission handling.